### PR TITLE
feat: Dashboard HTML プレビュー + 日本語パスリンク化 (task-807)

### DIFF
--- a/packages/maid-agent-messenger/src/__tests__/markdown-utils.test.ts
+++ b/packages/maid-agent-messenger/src/__tests__/markdown-utils.test.ts
@@ -199,6 +199,33 @@ describe("linkifyProjectPaths", () => {
     expect(result).toContain(">docs/設計（詳細）/overview.md</a>");
   });
 
+  // --- 日本語始まりディレクトリ（CJK prefix 対応） ---
+
+  it("日本語ディレクトリ名で始まるパスをリンク化する", () => {
+    const input = "<p>自動運転部/ec-ops/docs/overview.md を参照</p>";
+    const result = linkifyProjectPaths(input, PROJECT_PATH);
+    expect(result).toContain(">自動運転部/ec-ops/docs/overview.md</a>");
+  });
+
+  it("日本語ディレクトリ内の深いパスをリンク化する", () => {
+    const input = "<p>自動運転部/ec-ops/agents/scout/agent.py</p>";
+    const result = linkifyProjectPaths(input, PROJECT_PATH);
+    expect(result).toContain(">自動運転部/ec-ops/agents/scout/agent.py</a>");
+  });
+
+  it("日本語ディレクトリと英語ディレクトリが混在する場合も両方リンク化する", () => {
+    const input = "<p>自動運転部/ec-ops/docs/design.md と docs/plans/plan.md を参照</p>";
+    const result = linkifyProjectPaths(input, PROJECT_PATH);
+    expect(result).toContain(">自動運転部/ec-ops/docs/design.md</a>");
+    expect(result).toContain(">docs/plans/plan.md</a>");
+  });
+
+  it("単独の日本語単語（パス構造なし）はリンク化しない", () => {
+    const input = "<p>テスト という単語はリンクにならない</p>";
+    const result = linkifyProjectPaths(input, PROJECT_PATH);
+    expect(result).toBe(input);
+  });
+
   // --- パス終端の判定（#249対応） ---
 
   it("パス終端の)を含めない", () => {

--- a/packages/maid-agent-messenger/src/markdown-utils.ts
+++ b/packages/maid-agent-messenger/src/markdown-utils.ts
@@ -162,6 +162,7 @@ export const DEFAULT_PATH_PREFIXES: string[] = [
   "scripts",
   "\\.github",
   "config",
+  "[\\u4E00-\\u9FFF\\u3040-\\u30FF][\\w\\u4E00-\\u9FFF\\u3040-\\u30FF]*",  // 日本語始まりディレクトリ（自動運転部/ 等）。CJK句読点　-〿は除外
 ];
 
 /**

--- a/packages/maid-agent-messenger/src/routes/file-api-routes.ts
+++ b/packages/maid-agent-messenger/src/routes/file-api-routes.ts
@@ -263,6 +263,7 @@ router.get("/api/files/content", async (req: Request, res: Response) => {
     // ファイル読み込み
     const content = await fs.readFile(validation.resolvedPath, "utf-8");
     const isMarkdown = /\.(md|markdown)$/i.test(fileName);
+    const isHtml = /\.html?$/i.test(fileName);
 
     // Markdown → HTML変換（パスリンク化適用）
     let htmlContent: string | undefined;
@@ -282,6 +283,7 @@ router.get("/api/files/content", async (req: Request, res: Response) => {
       size: stats.size,
       modifiedAt: stats.mtime.toISOString(),
       isMarkdown,
+      isHtml,
       htmlContent,
       agentId,
     });

--- a/packages/maid-agent-messenger/src/routes/file-routes.ts
+++ b/packages/maid-agent-messenger/src/routes/file-routes.ts
@@ -148,6 +148,14 @@ function generateFileViewerHtml(filePath: string, projectPath: string): string {
           var contentEl = document.getElementById('content');
           if (data.isMarkdown && data.htmlContent) {
             contentEl.innerHTML = data.htmlContent;
+          } else if (data.isHtml) {
+            // HTMLファイルは iframe srcdoc でサンドボックス表示（XSS対策: JS実行なし）
+            var iframe = document.createElement('iframe');
+            iframe.setAttribute('srcdoc', data.content);
+            iframe.setAttribute('sandbox', 'allow-same-origin allow-forms');
+            iframe.style.cssText = 'width:100%;height:80vh;border:none;background:#fff;border-radius:6px;';
+            contentEl.innerHTML = '';
+            contentEl.appendChild(iframe);
           } else {
             // 非Markdownファイルはプレーンテキスト表示
             var pre = document.createElement('pre');

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -198,6 +198,7 @@ export interface FileContentResponse {
   size: number;
   modifiedAt: string;
   isMarkdown: boolean;
+  isHtml?: boolean;
   htmlContent?: string;
 }
 


### PR DESCRIPTION
## Summary

- **HTML ファイル表示修正**: ダッシュボードで HTML ファイルを開くと text/plain で表示される問題を修正。`<iframe srcdoc sandbox>` で XSS なしにレンダリング
- **日本語パスリンク化**: `自動運転部/ec-ops/docs/...` 等の CJK prefix ディレクトリをリンク化対応（`DEFAULT_PATH_PREFIXES` に Unicode パターン追加）
- **型定義拡張**: `FileContentResponse` に `isHtml?: boolean` を追加

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `packages/maid-agent-messenger/src/routes/file-api-routes.ts` | `isHtml` フラグ検出追加 |
| `packages/maid-agent-messenger/src/routes/file-routes.ts` | SPA JS に iframe srcdoc 分岐追加 |
| `packages/maid-agent-messenger/src/markdown-utils.ts` | CJK prefix パターン追加（句読点除外: U+4E00-U+9FFF + U+3040-U+30FF） |
| `packages/maid-agent-messenger/src/__tests__/markdown-utils.test.ts` | 日本語 prefix テスト 4 件追加 |
| `packages/types/src/api.ts` | `FileContentResponse.isHtml` 追加 |

## Test plan

- [x] `markdown-utils.test.ts` 64 件全通過（日本語 prefix 4 件を含む新規テスト含む）
- [x] `image-routes.test.ts`, `top-page-routes.test.ts` 等の既存テスト通過（回帰なし）
- [ ] 実機確認: ダッシュボードで `.html` ファイルを開くと iframe でレンダリングされること
- [ ] 実機確認: 報告書内の `自動運転部/ec-ops/...` パスがリンクされること

## 関連

- 調査レポート: `docs/maid-agent/research/dashboard-html-and-path-fix-investigation.md`（task-804）
- MobileSylvia 変更（HTML プレビュー + 日本語パス）は MobileSylvia 独立 git リポジトリに別途コミット

🤖 Generated with [Claude Code](https://claude.com/claude-code)