### PR TITLE
feat(task-891-3): description 文字数バリデーション追加（W-4）

### DIFF
--- a/global-templates/maid-agent-messenger/dist/routes/cli-api-routes.js
+++ b/global-templates/maid-agent-messenger/dist/routes/cli-api-routes.js
@@ -14,6 +14,7 @@ import { Router } from "express";
 import { executeCreateTask, executeAssignTask, executeGetMyTask, executeUpdateStatus, executeGetTeamStatus, } from "../services/index.js";
 import { getProjectPathFromRequest } from "../middleware/project-path.js";
 import { MAID_IDS } from "../types/index.js";
+import { VALIDATION } from "../utils/constants.js";
 export function createCliApiRoutes(deps = {}) {
     const { wsServer } = deps;
     const router = Router();
@@ -48,10 +49,9 @@ export function createCliApiRoutes(deps = {}) {
                 res.status(400).json({ error: "title is required" });
                 return;
             }
-            const MAX_DESCRIPTION_LENGTH = 10000;
-            if (description && typeof description === "string" && description.length > MAX_DESCRIPTION_LENGTH) {
+            if (description && typeof description === "string" && description.length > VALIDATION.MAX_DESCRIPTION_LENGTH) {
                 res.status(400).json({
-                    error: `description が上限文字数（${MAX_DESCRIPTION_LENGTH}文字）を超えています`,
+                    error: `description が上限文字数（${VALIDATION.MAX_DESCRIPTION_LENGTH}文字）を超えています`,
                     length: description.length,
                 });
                 return;

--- a/global-templates/maid-agent-messenger/dist/routes/cli-api-routes.js
+++ b/global-templates/maid-agent-messenger/dist/routes/cli-api-routes.js
@@ -48,6 +48,14 @@ export function createCliApiRoutes(deps = {}) {
                 res.status(400).json({ error: "title is required" });
                 return;
             }
+            const MAX_DESCRIPTION_LENGTH = 10000;
+            if (description && typeof description === "string" && description.length > MAX_DESCRIPTION_LENGTH) {
+                res.status(400).json({
+                    error: `description が上限文字数（${MAX_DESCRIPTION_LENGTH}文字）を超えています`,
+                    length: description.length,
+                });
+                return;
+            }
             const result = await executeCreateTask(projectPath, {
                 title,
                 description,

--- a/global-templates/maid-agent-messenger/dist/routes/task-api-routes.js
+++ b/global-templates/maid-agent-messenger/dist/routes/task-api-routes.js
@@ -90,6 +90,14 @@ export function createTaskApiRoutes(deps = {}) {
             mainStatus, subStatus, type, size, tentative, blockedBy, artifacts, artifactAdd, reviewStatus, 
             // V2.1 追加フィールド
             archived, actionRequired, } = req.body;
+            const MAX_DESCRIPTION_LENGTH = 10000;
+            if (description && typeof description === "string" && description.length > MAX_DESCRIPTION_LENGTH) {
+                res.status(400).json({
+                    error: `description が上限文字数（${MAX_DESCRIPTION_LENGTH}文字）を超えています`,
+                    length: description.length,
+                });
+                return;
+            }
             const result = await executeUpdateTask(projectPath, {
                 taskId: req.params.id,
                 status,
@@ -299,13 +307,14 @@ export function createTaskApiRoutes(deps = {}) {
                 artifacts: v2Data.v2Artifacts,
                 stats: v2Data.v2Stats,
                 // スキル化候補・改善提案（別セクション用）
+                // String() 変換: tasks.yaml の id が整数型で記載されても MobileSylvia が落ちないよう恒久対策 (#524-3)
                 skillCandidates: skillCandidatesResult.tasks.map((t) => ({
-                    id: t.id,
+                    id: String(t.id),
                     title: t.title,
                     description: "description" in t ? t.description : undefined,
                 })),
                 improvements: improvementsResult.tasks.map((t) => ({
-                    id: t.id,
+                    id: String(t.id),
                     title: t.title,
                     description: "description" in t ? t.description : undefined,
                 })),

--- a/global-templates/maid-agent-messenger/dist/routes/task-api-routes.js
+++ b/global-templates/maid-agent-messenger/dist/routes/task-api-routes.js
@@ -11,6 +11,7 @@ import { getJstTimestamp } from "../utils/yaml-helper.js";
 import { getProjectPathFromRequest } from "../middleware/project-path.js";
 import { convertMarkdownToHtml, linkifyProjectPaths } from "../markdown-utils.js";
 import { extractAgentIdFromPath } from "../utils/agent-image.js";
+import { VALIDATION } from "../utils/constants.js";
 export function createTaskApiRoutes(deps = {}) {
     const { wsServer } = deps;
     const router = Router();
@@ -90,10 +91,9 @@ export function createTaskApiRoutes(deps = {}) {
             mainStatus, subStatus, type, size, tentative, blockedBy, artifacts, artifactAdd, reviewStatus, 
             // V2.1 追加フィールド
             archived, actionRequired, } = req.body;
-            const MAX_DESCRIPTION_LENGTH = 10000;
-            if (description && typeof description === "string" && description.length > MAX_DESCRIPTION_LENGTH) {
+            if (description && typeof description === "string" && description.length > VALIDATION.MAX_DESCRIPTION_LENGTH) {
                 res.status(400).json({
-                    error: `description が上限文字数（${MAX_DESCRIPTION_LENGTH}文字）を超えています`,
+                    error: `description が上限文字数（${VALIDATION.MAX_DESCRIPTION_LENGTH}文字）を超えています`,
                     length: description.length,
                 });
                 return;

--- a/global-templates/maid-agent-messenger/dist/utils/constants.d.ts
+++ b/global-templates/maid-agent-messenger/dist/utils/constants.d.ts
@@ -1,4 +1,11 @@
 /**
+ * バリデーション関連の定数
+ */
+export declare const VALIDATION: {
+    /** description フィールドの最大文字数 (task-891-3 W-4) */
+    readonly MAX_DESCRIPTION_LENGTH: 10000;
+};
+/**
  * タイムアウト関連の定数
  * 散在していたマジックナンバーを集約
  */

--- a/global-templates/maid-agent-messenger/dist/utils/constants.js
+++ b/global-templates/maid-agent-messenger/dist/utils/constants.js
@@ -1,4 +1,11 @@
 /**
+ * バリデーション関連の定数
+ */
+export const VALIDATION = {
+    /** description フィールドの最大文字数 (task-891-3 W-4) */
+    MAX_DESCRIPTION_LENGTH: 10000,
+};
+/**
  * タイムアウト関連の定数
  * 散在していたマジックナンバーを集約
  */

--- a/packages/maid-agent-messenger/src/routes/cli-api-routes.ts
+++ b/packages/maid-agent-messenger/src/routes/cli-api-routes.ts
@@ -22,6 +22,7 @@ import {
 import { getProjectPathFromRequest } from "../middleware/project-path.js";
 import { MAID_IDS, type UpdatableStatus } from "../types/index.js";
 import type { DashboardWebSocketServer } from "../websocket/dashboard-ws.js";
+import { VALIDATION } from "../utils/constants.js";
 
 export interface CliApiRoutesDeps {
   wsServer?: DashboardWebSocketServer;
@@ -66,10 +67,9 @@ router.post("/api/tasks", async (req: Request, res: Response) => {
       return;
     }
 
-    const MAX_DESCRIPTION_LENGTH = 10000;
-    if (description && typeof description === "string" && description.length > MAX_DESCRIPTION_LENGTH) {
+    if (description && typeof description === "string" && description.length > VALIDATION.MAX_DESCRIPTION_LENGTH) {
       res.status(400).json({
-        error: `description が上限文字数（${MAX_DESCRIPTION_LENGTH}文字）を超えています`,
+        error: `description が上限文字数（${VALIDATION.MAX_DESCRIPTION_LENGTH}文字）を超えています`,
         length: description.length,
       });
       return;

--- a/packages/maid-agent-messenger/src/routes/cli-api-routes.ts
+++ b/packages/maid-agent-messenger/src/routes/cli-api-routes.ts
@@ -66,6 +66,15 @@ router.post("/api/tasks", async (req: Request, res: Response) => {
       return;
     }
 
+    const MAX_DESCRIPTION_LENGTH = 10000;
+    if (description && typeof description === "string" && description.length > MAX_DESCRIPTION_LENGTH) {
+      res.status(400).json({
+        error: `description が上限文字数（${MAX_DESCRIPTION_LENGTH}文字）を超えています`,
+        length: description.length,
+      });
+      return;
+    }
+
     const result = await executeCreateTask(projectPath, {
       title,
       description,

--- a/packages/maid-agent-messenger/src/routes/task-api-routes.ts
+++ b/packages/maid-agent-messenger/src/routes/task-api-routes.ts
@@ -24,6 +24,7 @@ import { getProjectPathFromRequest } from "../middleware/project-path.js";
 import type { DashboardWebSocketServer } from "../websocket/dashboard-ws.js";
 import { convertMarkdownToHtml, linkifyProjectPaths } from "../markdown-utils.js";
 import { extractAgentIdFromPath } from "../utils/agent-image.js";
+import { VALIDATION } from "../utils/constants.js";
 
 export interface TaskApiRoutesDeps {
   wsServer?: DashboardWebSocketServer;
@@ -128,10 +129,9 @@ router.patch("/api/tasks/:id", async (req: Request, res: Response) => {
       archived, actionRequired,
     } = req.body;
 
-    const MAX_DESCRIPTION_LENGTH = 10000;
-    if (description && typeof description === "string" && description.length > MAX_DESCRIPTION_LENGTH) {
+    if (description && typeof description === "string" && description.length > VALIDATION.MAX_DESCRIPTION_LENGTH) {
       res.status(400).json({
-        error: `description が上限文字数（${MAX_DESCRIPTION_LENGTH}文字）を超えています`,
+        error: `description が上限文字数（${VALIDATION.MAX_DESCRIPTION_LENGTH}文字）を超えています`,
         length: description.length,
       });
       return;

--- a/packages/maid-agent-messenger/src/routes/task-api-routes.ts
+++ b/packages/maid-agent-messenger/src/routes/task-api-routes.ts
@@ -128,6 +128,15 @@ router.patch("/api/tasks/:id", async (req: Request, res: Response) => {
       archived, actionRequired,
     } = req.body;
 
+    const MAX_DESCRIPTION_LENGTH = 10000;
+    if (description && typeof description === "string" && description.length > MAX_DESCRIPTION_LENGTH) {
+      res.status(400).json({
+        error: `description が上限文字数（${MAX_DESCRIPTION_LENGTH}文字）を超えています`,
+        length: description.length,
+      });
+      return;
+    }
+
     const result = await executeUpdateTask(projectPath, {
       taskId: req.params.id,
       status,

--- a/packages/maid-agent-messenger/src/utils/constants.ts
+++ b/packages/maid-agent-messenger/src/utils/constants.ts
@@ -1,4 +1,12 @@
 /**
+ * バリデーション関連の定数
+ */
+export const VALIDATION = {
+  /** description フィールドの最大文字数 (task-891-3 W-4) */
+  MAX_DESCRIPTION_LENGTH: 10000,
+} as const;
+
+/**
  * タイムアウト関連の定数
  * 散在していたマジックナンバーを集約
  */


### PR DESCRIPTION
## Summary

- `POST /api/tasks`（cli-api-routes.ts）に description 上限 10000 文字チェックを追加
- `PATCH /api/tasks/:id`（task-api-routes.ts）に description 上限 10000 文字チェックを追加
- 上限超過時: HTTP 400 + `{ error: "description が上限文字数（10000文字）を超えています", length: <実文字数> }`

設計書: `docs/maid-agent/decisions/maidctl-robustness-design-2026-05-23.md` W-4（3の方式B）

## Test plan

- [ ] POST /api/tasks で description が 10000 文字以下 → 201 正常作成
- [ ] POST /api/tasks で description が 10001 文字以上 → 400 エラー返却
- [ ] PATCH /api/tasks/:id で description が 10000 文字以下 → 200 正常更新
- [ ] PATCH /api/tasks/:id で description が 10001 文字以上 → 400 エラー返却
- [ ] description が undefined/null の場合はバリデーションをスキップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)