### PR TITLE
fix(task-968): agent-status-hook.sh の lock を flock→mkdir/rmdir 統一

### DIFF
--- a/project-templates/system/bin/agent-status-hook.sh
+++ b/project-templates/system/bin/agent-status-hook.sh
@@ -67,6 +67,8 @@ if acquire_mkdir_lock "$LOCK_DIR"; then
         echo "claude_status: ${STATUS}" >> "$MAID_YAML"
     fi
     rmdir "$LOCK_DIR" 2>/dev/null || true
+else
+    echo "[agent-status-hook] ロック取得失敗: ${LOCK_DIR} (試行 ${LOCK_MAX_ATTEMPTS} 回超過)" >&2
 fi
 
 # idle 遷移時: busy キューをフラッシュ

--- a/project-templates/system/bin/agent-status-hook.sh
+++ b/project-templates/system/bin/agent-status-hook.sh
@@ -28,15 +28,46 @@ MAID_YAML=$(grep -rl "session_id: ${SESSION_ID}" "${MAID_DIR}" 2>/dev/null | hea
 
 AGENT_ID=$(basename "$MAID_YAML" .yaml)
 
-# claude_status フィールドを更新（flock で maidctl との競合を防ぐ）
-(
-    flock -x 200
+# claude_status フィールドを更新（mkdir ロックで maidctl/proper-lockfile との競合を防ぐ）
+LOCK_DIR="${MAID_YAML}.lock"
+LOCK_STALE_SEC=10
+LOCK_WAIT_INTERVAL=0.1
+LOCK_MAX_ATTEMPTS=100
+
+acquire_mkdir_lock() {
+    local lockdir="$1"
+    local attempt=0
+    while ! mkdir "$lockdir" 2>/dev/null; do
+        if [ -d "$lockdir" ]; then
+            # ディレクトリ存在: stale チェック（proper-lockfile の stale=10秒と同期）
+            local mtime now age
+            mtime=$(stat -c %Y "$lockdir" 2>/dev/null || echo 0)
+            now=$(date +%s)
+            age=$(( now - mtime ))
+            if [ "$age" -gt "$LOCK_STALE_SEC" ]; then
+                rmdir "$lockdir" 2>/dev/null || true
+                continue
+            fi
+        elif [ -f "$lockdir" ]; then
+            # ファイル存在: 旧 flock 方式の残留ファイルを削除して再試行
+            rm -f "$lockdir" 2>/dev/null || true
+            continue
+        fi
+        sleep "$LOCK_WAIT_INTERVAL"
+        attempt=$(( attempt + 1 ))
+        [ "$attempt" -ge "$LOCK_MAX_ATTEMPTS" ] && return 1
+    done
+    return 0
+}
+
+if acquire_mkdir_lock "$LOCK_DIR"; then
     if grep -q "^claude_status:" "$MAID_YAML" 2>/dev/null; then
         sed -i "s/^claude_status:.*/claude_status: ${STATUS}/" "$MAID_YAML"
     else
         echo "claude_status: ${STATUS}" >> "$MAID_YAML"
     fi
-) 200>"${MAID_YAML}.lock"
+    rmdir "$LOCK_DIR" 2>/dev/null || true
+fi
 
 # idle 遷移時: busy キューをフラッシュ
 if [ "$STATUS" = "idle" ]; then


### PR DESCRIPTION
## Summary

- `agent-status-hook.sh` の flock（ファイル作成）を `mkdir/rmdir` 方式に変更
- `maid/{agent_id}.yaml.lock` で lock 方式が混在し `ENOTDIR` エラーが発生する構造バグを修正（task-968）
- `proper-lockfile`（maidctl 側）と同じ `mkdir/rmdir` 方式に統一し、両者が互換性を持って動作するようになります

## 変更詳細

**変更前（flock 方式）**:
```bash
(
    flock -x 200
    sed -i "s/^claude_status:.*/claude_status: ${STATUS}/" "$MAID_YAML"
) 200>"${MAID_YAML}.lock"
# → .lock がファイルとして残留 → proper-lockfile の mkdir が ENOTDIR
```

**変更後（mkdir/rmdir 方式）**:
```bash
acquire_mkdir_lock() { ... mkdir ... stale=10秒 ... }
if acquire_mkdir_lock "$LOCK_DIR"; then
    sed -i ...
    rmdir "$LOCK_DIR"
fi
# → .lock がディレクトリ（proper-lockfile と互換）→ ENOTDIR 解消
```

**stale・残留ファイル対応**:
- ロックディレクトリが 10秒以上残留 → stale として自動削除（proper-lockfile の stale=10000ms と同期）
- 旧 flock 由来の残留ファイルが存在する場合 → 自動削除して mkdir 再試行

## Test plan

- [x] 構文チェック（`bash -n`）: OK
- [x] テスト1: 正常な mkdir ロック取得・解放: PASS
- [x] テスト2: 旧 flock 残留ファイルがある場合の自動クリーンアップ: PASS
- [x] テスト3: 並行アクセス競合テスト（P1 保持中に P2 が待機→解放後取得）: PASS
- [x] LF 維持（CRLF なし）確認: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)