### PR TITLE
fix(task-973): notify 途中分割を解消（閾値引き上げ + notify 単位保証）

### DIFF
--- a/project-templates/system/bin/flush-notify-queue.sh
+++ b/project-templates/system/bin/flush-notify-queue.sh
@@ -90,6 +90,9 @@ while IFS= read -r line; do
     msg=$(echo "$line" | sed 's/^\[[^]]*\] [^:]*: //')
     [ -z "$msg" ] && continue
 
+    # \n エスケープを実改行に復元（maid-notify が改行入り notify を1行にエスケープして保存したもの）
+    msg="${msg//\\n/$'\n'}"
+
     if [ "$CHUNK_DONE" = "true" ]; then
         printf '%s\n' "$line" >> "$REMAINING_FILE"
         continue
@@ -103,6 +106,7 @@ while IFS= read -r line; do
     fi
 
     # 件数または文字数が上限に達したら、このメッセージ以降を残りに回す
+    # 1 notify は分割しない: 1件目が閾値を超えていても CHUNK が空なら必ず送る
     if [ -n "$CHUNK" ] && { [ "$CHUNK_MSGS" -ge "$BATCH_CHUNK_COUNT" ] || [ "$new_len" -gt "$BATCH_CHUNK_CHARS" ]; }; then
         CHUNK_DONE=true
         printf '%s\n' "$line" >> "$REMAINING_FILE"

--- a/project-templates/system/bin/maid-notify
+++ b/project-templates/system/bin/maid-notify
@@ -213,6 +213,7 @@ check_agent_busy() {
 }
 
 # ビジーキューにメッセージを追加（flock 排他・無制限 append）
+# 改行入りメッセージは \n にエスケープして1行に収める（1 notify = 1行 = notify 単位保証）
 enqueue_busy_message() {
     local target="$1"
     local message="$2"
@@ -223,9 +224,12 @@ enqueue_busy_message() {
     local queue_file="${QUEUE_DIR}/${target}.txt"
     local lock_file="${QUEUE_DIR}/${target}.lock"
 
+    # 改行を \n（リテラル）にエスケープして1行1エントリを保証（task-973）
+    local msg_escaped="${message//$'\n'/\\n}"
+
     (
         flock -x 9
-        echo "[${timestamp}] ${sender}: ${message}" >> "$queue_file"
+        echo "[${timestamp}] ${sender}: ${msg_escaped}" >> "$queue_file"
     ) 9>"$lock_file"
 }
 

--- a/project-templates/system/config/settings.yaml
+++ b/project-templates/system/config/settings.yaml
@@ -144,8 +144,9 @@ screenshot:
 # 通知設定
 notify:
   # チャンク分割の上限（flush-notify-queue.sh が使用）
-  batch_chunk_count: 8    # 1チャンクあたりの最大メッセージ件数
-  batch_chunk_chars: 1000 # 1チャンクあたりの最大文字数
+  # notify 単位で数えるため件数は少なめ・文字数は send-keys 安全上限（~4KB）内で余裕を持って設定
+  batch_chunk_count: 5    # 1チャンクあたりの最大 notify 件数（旧: 8）
+  batch_chunk_chars: 3500 # 1チャンクあたりの最大文字数（旧: 1000 → 3500 に引き上げ・task-973）
 
 # ログ設定
 log:


### PR DESCRIPTION
## Summary

- 改行入り notify が chunk 境界で途中分割される問題を修正（task-973）
- 1 notify が必ず1単位として届くよう保証

## 原因

`maid-notify` の `enqueue_busy_message` が `echo` で書き込む際、改行入り `$message` が複数行になり queue に複数エントリとして記録される。`flush-notify-queue.sh` の `while read line` は1行ずつ処理するため、chunk 境界でメッセージが途中分割される。

## 変更内容

### ① settings.yaml: 閾値引き上げ
| 設定 | 変更前 | 変更後 |
|------|------|------|
| `batch_chunk_count` | 8 | 5（notify 単位で数えるため少なめ） |
| `batch_chunk_chars` | 1000 | 3500（send-keys 安全上限内） |

### ② notify 単位保証

**maid-notify（書き込み側）**:
```bash
# 改行を \n にエスケープして1行1エントリを保証
local msg_escaped="${message//$'\n'/\\n}"
echo "[${timestamp}] ${sender}: ${msg_escaped}" >> "$queue_file"
```

**flush-notify-queue.sh（読み取り側）**:
```bash
msg=$(echo "$line" | sed 's/^\[[^]]*\] [^:]*: //')
# \n エスケープを実改行に復元（notify 単位の改行を復元）
msg="${msg//\\n/$'\n'}"
```

## Test plan

- [x] テスト1: 改行入りメッセージのエスケープ（1行に収まる）: PASS
- [x] テスト2: flush側の `\n` 復元（3行に戻る）: PASS
- [x] テスト3: queue パーサーが正しく1 notify として処理: PASS
- [x] テスト4: 複数 notify の FIFO 順序保持: PASS
- [x] テスト5: chunk 境界（5件目で分割）: PASS
- [x] テスト6: LF 維持（CRLF なし）: OK
- [x] author=may / committer=may 確認: OK
- [x] 実体（`.maid-agent/system/bin/`）への同期: 完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)