### PR TITLE
feat(task-974): sync-project-settings.sh 追加（全上書き防止・固有設定保持）

### DIFF
--- a/project-templates/system/bin/sync-project-settings.sh
+++ b/project-templates/system/bin/sync-project-settings.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# sync-project-settings.sh - project-templates/settings.yaml を実体に安全に同期する
+# ★ 全上書き（cp）の代わりに必ずこのスクリプトを使用すること
+#
+# 動作:
+#   1. 実体から「プロジェクト固有設定」（PRESERVED_TOP_KEYS）を退避
+#   2. テンプレートの内容（batch_chunk 等のシステム設定）を実体に反映
+#   3. 退避した固有設定を復元
+#
+# 保護対象（実体のみに存在する可能性があるキー）:
+#   model    - LLMモデル設定（執事がプロジェクトに応じて設定）
+#   provider - LLMプロバイダ設定（AWS Bedrock 等）
+#
+# 使い方:
+#   bash sync-project-settings.sh <template.yaml> <target.yaml>
+#   bash sync-project-settings.sh <template.yaml> <target.yaml> --dry-run
+#
+# 例:
+#   bash project-templates/system/bin/sync-project-settings.sh \
+#        project-templates/system/config/settings.yaml \
+#        .maid-agent/system/config/settings.yaml
+
+set -euo pipefail
+
+TEMPLATE="${1:-}"
+TARGET="${2:-}"
+DRY_RUN="${3:-}"
+
+PRESERVED_TOP_KEYS=(model provider)
+
+# =============================================================================
+# 引数チェック
+# =============================================================================
+
+if [ -z "$TEMPLATE" ] || [ -z "$TARGET" ]; then
+    cat >&2 <<EOF
+使用法: $0 <template-settings.yaml> <target-settings.yaml> [--dry-run]
+
+  template: project-templates/system/config/settings.yaml
+  target:   .maid-agent/system/config/settings.yaml
+  --dry-run: 実際には変更せず、マージ結果を標準出力に表示
+
+保護対象キー: ${PRESERVED_TOP_KEYS[*]}
+EOF
+    exit 1
+fi
+
+[ -f "$TEMPLATE" ] || { echo "エラー: テンプレートが見つかりません: $TEMPLATE" >&2; exit 1; }
+[ -f "$TARGET" ]   || { echo "エラー: 実体が見つかりません: $TARGET" >&2; exit 1; }
+
+# python3 + PyYAML の存在確認
+if ! python3 -c "import yaml" 2>/dev/null; then
+    echo "エラー: python3-yaml が必要です" >&2
+    echo "  インストール: pip3 install pyyaml  または  sudo apt install python3-yaml" >&2
+    exit 1
+fi
+
+# =============================================================================
+# YAML マージ処理
+# =============================================================================
+
+MERGED=$(python3 - "$TEMPLATE" "$TARGET" "${PRESERVED_TOP_KEYS[@]}" <<'PYTHON'
+import yaml
+import sys
+
+template_path = sys.argv[1]
+target_path = sys.argv[2]
+preserved_keys = sys.argv[3:]
+
+def load_yaml(path):
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+template = load_yaml(template_path)
+target = load_yaml(target_path)
+
+# テンプレートをベースに、保護キーは実体の値を優先（Noneでなければ）
+merged = dict(template)
+actually_preserved = []
+for key in preserved_keys:
+    if key in target and target[key] is not None:
+        merged[key] = target[key]
+        actually_preserved.append(key)
+
+# 結果を標準出力に YAML で出力
+print(yaml.dump(merged, allow_unicode=True, default_flow_style=False,
+                sort_keys=False, indent=2).rstrip())
+
+# 保護したキーをログに出力（stderr）
+import sys as _sys
+if actually_preserved:
+    print(f"  保護したキー: {', '.join(actually_preserved)}", file=_sys.stderr)
+else:
+    print("  保護したキー: なし（実体に固有設定なし）", file=_sys.stderr)
+PYTHON
+)
+
+# =============================================================================
+# dry-run または実際の書き込み
+# =============================================================================
+
+if [ "$DRY_RUN" = "--dry-run" ]; then
+    echo "=== [DRY RUN] マージ結果（実体には書き込みません） ==="
+    echo "$MERGED"
+    echo "=== [DRY RUN] 終了 ==="
+    exit 0
+fi
+
+# バックアップ作成
+BACKUP="${TARGET}.$(date +%Y%m%d_%H%M%S).backup"
+cp "$TARGET" "$BACKUP"
+echo "バックアップ: $BACKUP"
+
+# 書き込み
+echo "$MERGED" > "$TARGET"
+echo "✅ 同期完了: $TARGET"
+echo "   テンプレート: $TEMPLATE"
+echo "   ★ 全上書き(cp)でなくこのスクリプトで同期したため固有設定は保持されています"


### PR DESCRIPTION
## Summary

- task-973 の cp 全上書きで model 設定が消失した問題の恒久再発防止（task-974）
- `sync-project-settings.sh` を追加: settings.yaml の安全な実体同期スクリプト

## 原因（task-973 副作用の事実確認）

task-973 の実体同期で以下のコマンドを実行（全上書き）:
```bash
cp project-templates/system/config/settings.yaml .maid-agent/system/config/settings.yaml
```
テンプレート版は `model:` がコメントアウトのため、実体の `model` セクション（執事設定: opus-4-8/opus/sonnet）が消失した。

## 対策: sync-project-settings.sh

```bash
# 全上書き（cp）の代わりに必ずこれを使用する
bash project-templates/system/bin/sync-project-settings.sh \
     project-templates/system/config/settings.yaml \
     .maid-agent/system/config/settings.yaml
```

**動作**:
1. 実体から保護キー（`model`, `provider`）を退避
2. テンプレートの内容（notify 等のシステム設定）を反映（python3 + PyYAML）
3. 退避した固有設定を復元
4. タイムスタンプ付きバックアップを自動作成

**保護対象キー**: `model`（LLMモデル設定）・`provider`（プロバイダ設定）

## 洗い出し結果（model 以外の固有設定）

実体と比較した結果、現状では `model` のみがプロジェクト固有設定。
`provider` は将来的に固有設定が入る可能性があるため保護対象に含めた。

## Test plan

- [x] テスト1: dry-run で model 保持確認（opus-4-8/opus/sonnet が出力される）: PASS
- [x] テスト2: batch_chunk_chars が 3500 に保たれているか: PASS
- [x] テスト3: model なし実体でも正常動作: PASS
- [x] テスト4: 実際に同期実行・model 保持・batch_chunk 反映の実機確認: PASS
- [x] LF 維持（CRLF なし）: OK
- [x] 実行権限 100755: OK
- [x] author=may / committer=may: OK
- [x] 実体（`.maid-agent/system/bin/`）への同期: 完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)