### PR TITLE
feat(task-995-1): MaidAgent GIT env シェル export 化・email統一・CODELODIS_AGENT_ID追加

### DIFF
--- a/packages/vscode/src/agents/__tests__/watchdog-launch-command-parity.test.ts
+++ b/packages/vscode/src/agents/__tests__/watchdog-launch-command-parity.test.ts
@@ -37,7 +37,8 @@ import type { MaidAgentSettings } from '../../utils/settings-loader.js';
 
 // watchdog.sh のパス（テストファイルから6階層上がって MaidsHouse ルートへ）
 // __dirname: packages/vscode/src/agents/__tests__
-const MAIDS_HOUSE_ROOT = path.resolve(__dirname, '../../../../../../');
+// MAIDS_HOUSE_ROOT 環境変数で上書き可能（git worktree からのテスト実行時に使用）
+const MAIDS_HOUSE_ROOT = process.env['MAIDS_HOUSE_ROOT'] ?? path.resolve(__dirname, '../../../../../../');
 const WATCHDOG_PATH = path.join(MAIDS_HOUSE_ROOT, '.maid-agent/system/bin/watchdog.sh');
 const REAL_MAID_AGENT_PATH = path.join(MAIDS_HOUSE_ROOT, '.maid-agent');
 
@@ -50,13 +51,15 @@ const REAL_MAID_AGENT_PATH = path.join(MAIDS_HOUSE_ROOT, '.maid-agent');
 
 /** 起動コマンドに含まれなければならない要素 */
 const LAUNCH_CMD_SPEC = {
-    /** 必須環境変数プレフィックス */
-    requiredEnvVarPrefix: 'CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1',
+    /** 必須環境変数プレフィックス（export 形式） */
+    requiredEnvVarPrefix: 'export CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1',
     /** Git Author/Committer 環境変数（agentId から導出） */
     gitAuthorEnvVar: (agentId: string) => `GIT_AUTHOR_NAME=${agentId}`,
-    gitAuthorEmailEnvVar: (agentId: string) => `GIT_AUTHOR_EMAIL=${agentId}@maidshouse.local`,
+    gitAuthorEmailEnvVar: (agentId: string) => `GIT_AUTHOR_EMAIL=${agentId}@maid-agent.local`,
     gitCommitterEnvVar: (agentId: string) => `GIT_COMMITTER_NAME=${agentId}`,
-    gitCommitterEmailEnvVar: (agentId: string) => `GIT_COMMITTER_EMAIL=${agentId}@maidshouse.local`,
+    gitCommitterEmailEnvVar: (agentId: string) => `GIT_COMMITTER_EMAIL=${agentId}@maid-agent.local`,
+    /** CODELODIS_AGENT_ID 環境変数（agentId と一致） */
+    codelodisAgentIdEnvVar: (agentId: string) => `CODELODIS_AGENT_ID=${agentId}`,
     /** 必須フラグ */
     requiredFlags: [
         '--dangerously-skip-permissions',
@@ -87,10 +90,11 @@ function buildTsLaunchCommand(
     const providerEnvVars = getProviderEnvVars(settings, agentId, role);
     const envVars = {
         CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
+        CODELODIS_AGENT_ID: agentId,
         GIT_AUTHOR_NAME: agentId,
-        GIT_AUTHOR_EMAIL: `${agentId}@maidshouse.local`,
+        GIT_AUTHOR_EMAIL: `${agentId}@maid-agent.local`,
         GIT_COMMITTER_NAME: agentId,
-        GIT_COMMITTER_EMAIL: `${agentId}@maidshouse.local`,
+        GIT_COMMITTER_EMAIL: `${agentId}@maid-agent.local`,
         ...providerEnvVars,
     };
     return buildBashClaudeCommand(agentId, modelFlag, envVars, initialPrompt);
@@ -141,11 +145,11 @@ describe('launch command spec (TypeScript side)', () => {
         },
     };
 
-    it('CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 が先頭に含まれること', () => {
+    it('export CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 が先頭に含まれること', () => {
         const cmd = buildTsLaunchCommand(settings, 'luna', 'maid');
         expect(cmd).toContain(LAUNCH_CMD_SPEC.requiredEnvVarPrefix);
-        // 環境変数はコマンドの先頭に来ること
-        expect(cmd.indexOf('CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD')).toBeLessThan(
+        // export 文はコマンドの先頭に来ること
+        expect(cmd.indexOf('export CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD')).toBeLessThan(
             cmd.indexOf('claude '),
         );
     });
@@ -155,7 +159,7 @@ describe('launch command spec (TypeScript side)', () => {
         expect(cmd).toContain(LAUNCH_CMD_SPEC.gitAuthorEnvVar('luna'));
     });
 
-    it('GIT_AUTHOR_EMAIL が agentId@maidshouse.local で含まれること', () => {
+    it('GIT_AUTHOR_EMAIL が agentId@maid-agent.local で含まれること', () => {
         const cmd = buildTsLaunchCommand(settings, 'luna', 'maid');
         expect(cmd).toContain(LAUNCH_CMD_SPEC.gitAuthorEmailEnvVar('luna'));
     });
@@ -165,9 +169,14 @@ describe('launch command spec (TypeScript side)', () => {
         expect(cmd).toContain(LAUNCH_CMD_SPEC.gitCommitterEnvVar('luna'));
     });
 
-    it('GIT_COMMITTER_EMAIL が agentId@maidshouse.local で含まれること', () => {
+    it('GIT_COMMITTER_EMAIL が agentId@maid-agent.local で含まれること', () => {
         const cmd = buildTsLaunchCommand(settings, 'luna', 'maid');
         expect(cmd).toContain(LAUNCH_CMD_SPEC.gitCommitterEmailEnvVar('luna'));
+    });
+
+    it('CODELODIS_AGENT_ID が agentId で含まれること', () => {
+        const cmd = buildTsLaunchCommand(settings, 'luna', 'maid');
+        expect(cmd).toContain(LAUNCH_CMD_SPEC.codelodisAgentIdEnvVar('luna'));
     });
 
     it('agentId が変わると GIT 環境変数も変わること', () => {
@@ -263,7 +272,7 @@ model:
         }
     });
 
-    it('CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 が含まれること', () => {
+    it('export CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 が含まれること', () => {
         const cmd = getBashLaunchCommand('luna', tempSettingsPath);
         expect(cmd).toContain(LAUNCH_CMD_SPEC.requiredEnvVarPrefix);
     });
@@ -273,7 +282,7 @@ model:
         expect(cmd).toContain(LAUNCH_CMD_SPEC.gitAuthorEnvVar('luna'));
     });
 
-    it('GIT_AUTHOR_EMAIL が agentId@maidshouse.local で含まれること', () => {
+    it('GIT_AUTHOR_EMAIL が agentId@maid-agent.local で含まれること', () => {
         const cmd = getBashLaunchCommand('luna', tempSettingsPath);
         expect(cmd).toContain(LAUNCH_CMD_SPEC.gitAuthorEmailEnvVar('luna'));
     });
@@ -283,9 +292,14 @@ model:
         expect(cmd).toContain(LAUNCH_CMD_SPEC.gitCommitterEnvVar('luna'));
     });
 
-    it('GIT_COMMITTER_EMAIL が agentId@maidshouse.local で含まれること', () => {
+    it('GIT_COMMITTER_EMAIL が agentId@maid-agent.local で含まれること', () => {
         const cmd = getBashLaunchCommand('luna', tempSettingsPath);
         expect(cmd).toContain(LAUNCH_CMD_SPEC.gitCommitterEmailEnvVar('luna'));
+    });
+
+    it('CODELODIS_AGENT_ID が agentId で含まれること', () => {
+        const cmd = getBashLaunchCommand('luna', tempSettingsPath);
+        expect(cmd).toContain(LAUNCH_CMD_SPEC.codelodisAgentIdEnvVar('luna'));
     });
 
     it('--dangerously-skip-permissions が含まれること', () => {

--- a/packages/vscode/src/agents/agent-startup.ts
+++ b/packages/vscode/src/agents/agent-startup.ts
@@ -105,10 +105,11 @@ function buildClaudeCommand(
     const providerEnvVars = getProviderEnvVars(ctx.settings, agentId, role);
     const envVars = {
         CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
+        CODELODIS_AGENT_ID: agentId,
         GIT_AUTHOR_NAME: agentId,
-        GIT_AUTHOR_EMAIL: `${agentId}@maidshouse.local`,
+        GIT_AUTHOR_EMAIL: `${agentId}@maid-agent.local`,
         GIT_COMMITTER_NAME: agentId,
-        GIT_COMMITTER_EMAIL: `${agentId}@maidshouse.local`,
+        GIT_COMMITTER_EMAIL: `${agentId}@maid-agent.local`,
         ...providerEnvVars,
     };
 

--- a/packages/vscode/src/utils/shell-escape.ts
+++ b/packages/vscode/src/utils/shell-escape.ts
@@ -84,7 +84,8 @@ export function quoteArg(value: string, shell: ShellType): string {
  * 環境変数をセットしてコマンドを実行する構文を構築
  *
  * シェルに応じた環境変数設定構文でコマンドをラップする。
- * - bash: `VAR1=value1 VAR2=value2 command`
+ * - bash: `export VAR1=value1 VAR2=value2 && command`
+ *   （export により bash セッション全体に継承され、再起動後も有効）
  * - powershell: `$env:VAR1 = 'value1'; $env:VAR2 = 'value2'; command`
  */
 export function buildCommandWithEnvVars(
@@ -109,7 +110,7 @@ export function buildCommandWithEnvVars(
             const envParts = entries
                 .map(([key, value]) => `${key}=${value}`)
                 .join(' ');
-            return `${envParts} ${command}`;
+            return `export ${envParts} && ${command}`;
         }
     }
 }


### PR DESCRIPTION
## Summary

- `buildCommandWithEnvVars`（bash）を inline 前置 → `export VAR=value && command` 形式に変更
- email ドメインを `@maid-agent.local` に統一（旧: `@maidshouse.local`）
- `CODELODIS_AGENT_ID=agentId` を追加（PROVENANCE_CHECK の照合を有効化）
- `watchdog.sh` も同様に更新（TS-bash parity 維持）
- parity test を新形式・新 spec に更新。`MAIDS_HOUSE_ROOT` 環境変数でワークツリーからも実行可能に

## 背景（#994-2 設計書より）

現行セッションで GIT env が `/proc/PID/environ` に到達していない問題を解消する。
inline 前置は bash セッション環境を変更しないため、watchdog 再起動後の claude に env が引き継がれない。
export 形式にすることで bash セッション全体に継承され、再起動後も有効になる。

## Test plan
- [x] parity test 全 34 件 PASS（TS vs bash 完全一致確認済み）
- [x] TypeScript 型チェック PASS
- [x] PROVENANCE_CHECK: emma 名義確認済み
- [ ] セッション再起動後の `/proc/PID/environ` 実測による GIT env 到達確認（実施手順は PR description 参照）

## 再起動後の検証手順（受け入れ条件）

```bash
# 1. MaidAgentController から新セッションでメイドを起動（emma の場合）
# 2. 起動後に emma の claude PID を取得
EMMA_PID=$(pgrep -f "roles/emma" | head -1)
# 3. /proc で GIT env 到達を確認
cat /proc/$EMMA_PID/environ | tr '\0' '\n' | grep -E "GIT_AUTHOR|GIT_COMMITTER|CODELODIS_AGENT_ID"
# 期待値:
# GIT_AUTHOR_NAME=emma
# GIT_AUTHOR_EMAIL=emma@maid-agent.local
# GIT_COMMITTER_NAME=emma
# GIT_COMMITTER_EMAIL=emma@maid-agent.local
# CODELODIS_AGENT_ID=emma
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)