### PR TITLE
feat(maidctl): C-1 checkpoint pass コマンド追加（Type B 通過型チェックポイント）

### DIFF
--- a/global-templates/bin/maidctl
+++ b/global-templates/bin/maidctl
@@ -1355,6 +1355,95 @@ cmd_my_status() {
 }
 
 # =============================================================================
+# checkpoint サブコマンド（C-1: Type B 通過型チェックポイント記録）
+# =============================================================================
+#
+# set my-status --substatus checkpoint（Type A・停止型）とは概念が異なる。
+# Type A は状態遷移（blocked への遷移・上位者の判断待ちで停止）を伴うが、
+# Type B は状態遷移を伴わない「記録操作」のみ。作業を止めずに暫定判断の
+# 内容と根拠を記録し、事後確認待ちとして対象タスクに積む。
+
+cmd_checkpoint_pass() {
+  local agent_id=""
+  local summary=""
+  local task_id=""
+  local json_output=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --summary|-m) summary="$2"; shift 2 ;;
+      --task) task_id="$2"; shift 2 ;;
+      --json) json_output=true; shift ;;
+      --help|-h)
+        echo "使用法: maidctl checkpoint pass --summary TEXT [オプション]"
+        echo ""
+        echo "Type B（通過型チェックポイント）を記録する。"
+        echo "set my-status --substatus checkpoint（Type A・停止型）とは異なり、"
+        echo "状態遷移を伴わない記録操作。作業を止めずに暫定判断を記録できる。"
+        echo ""
+        echo "オプション:"
+        echo "  --summary, -m TEXT  暫定判断の内容と根拠（必須）"
+        echo "  --task ID           対象タスクID（省略時は現在の my-task）"
+        echo "  --json              JSON出力"
+        return 0
+        ;;
+      -*)
+        echo "エラー: 不明なオプション: $1" >&2
+        echo "  -h/--help でオプション一覧を確認できます" >&2
+        exit $EXIT_INVALID_ARGS
+        ;;
+      *)
+        echo "エラー: 不明な引数: $1" >&2
+        exit $EXIT_INVALID_ARGS
+        ;;
+    esac
+  done
+
+  if [ -z "$summary" ]; then
+    echo "エラー: --summary を指定してください" >&2
+    echo "使用法: maidctl checkpoint pass --summary TEXT [--task ID]" >&2
+    exit $EXIT_INVALID_ARGS
+  fi
+
+  # 記録者IDをtmux/psmuxウィンドウ名から自動取得
+  agent_id=$(get_agent_id_from_multiplexer) || {
+    echo "エラー: エージェントIDを取得できません（tmuxウィンドウ名からの自動取得に失敗しました）" >&2
+    exit $EXIT_INVALID_ARGS
+  }
+
+  # --task 省略時は現在の my-task の報告書から task_id を解決
+  if [ -z "$task_id" ]; then
+    local project_dir="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+    task_id=$(grep -m1 "task_id:" \
+      "$project_dir/.maid-agent/system/data/reports/current_${agent_id}.md" 2>/dev/null \
+      | sed 's/.*task_id: *//' | tr -d ' ')
+    if [ -z "$task_id" ]; then
+      echo "エラー: 対象タスクIDを解決できません。--task で明示してください" >&2
+      exit $EXIT_INVALID_ARGS
+    fi
+  fi
+
+  # "task-" プレフィックスを除去してAPIパスに使用
+  local task_id_num
+  task_id_num=$(echo "$task_id" | sed 's/^task-//')
+
+  local data
+  data=$(jq -n --arg s "$summary" --arg a "$agent_id" \
+    '{checkpointPassAdd: {summary: $s, agentId: $a}}')
+
+  local result
+  result=$(api_request PATCH "/api/tasks/${task_id_num}" "$data")
+
+  if [ "$json_output" = true ]; then
+    echo "$result"
+  else
+    echo "通過型CP記録完了。事後確認待ちキューに追加しました。"
+    echo "  task: ${task_id}"
+    echo "  summary: ${summary}"
+  fi
+}
+
+# =============================================================================
 # team サブコマンド
 # =============================================================================
 
@@ -2194,6 +2283,32 @@ main() {
         *)
           echo "エラー: 不明な対象: $1"
           echo "使用法: maidctl run <migrate>"
+          exit $EXIT_INVALID_ARGS
+          ;;
+      esac
+      ;;
+    checkpoint)
+      shift
+      case "${1:-}" in
+        pass) shift; cmd_checkpoint_pass "$@" ;;
+        --help|-h)
+          echo "使用法: maidctl checkpoint <サブコマンド> [オプション]"
+          echo ""
+          echo "サブコマンド:"
+          echo "  pass  Type B（通過型チェックポイント）を記録"
+          echo ""
+          echo "オプション（pass）:"
+          echo "  --summary, -m TEXT  暫定判断の内容と根拠（必須）"
+          echo "  --task ID           対象タスクID（省略時は現在の my-task）"
+          ;;
+        "")
+          echo "エラー: サブコマンドを指定してください"
+          echo "使用法: maidctl checkpoint <pass>"
+          exit $EXIT_INVALID_ARGS
+          ;;
+        *)
+          echo "エラー: 不明なサブコマンド: $1"
+          echo "使用法: maidctl checkpoint <pass>"
           exit $EXIT_INVALID_ARGS
           ;;
       esac

--- a/global-templates/bin/test/maidctl-checkpoint-pass.test.sh
+++ b/global-templates/bin/test/maidctl-checkpoint-pass.test.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# maidctl checkpoint pass テスト（task-1454-1 / C-1）
+#
+# 背景: Type B（通過型チェックポイント）を記録する新動詞
+# `maidctl checkpoint pass --summary "..."` の実装（cmd_checkpoint_pass）を、
+# 実際に配布される maidctl から関数定義のみを抽出して検証する。
+# サーバー通信部分（api_request）とエージェントID自動取得
+# （get_agent_id_from_multiplexer）はスタブに置き換え、CLI側の
+# 引数検証・タスクID解決ロジックのみを対象とする。
+# サーバー側の実際の永続化ロジック（checkpointPassAdd の配列追記）は
+# packages/maid-agent-messenger/src/__tests__/services/
+# task-crud-update-checkpoint-pass.test.ts で別途検証済み。
+#
+# 完了条件:
+#   - 正常系: --summary 指定 → api_request が期待どおりの PATCH body で呼ばれる
+#   - 正常系: --task 省略時、報告書(current_<agent>.md)から task_id を解決する
+#   - 正常系: --task 明示時はそちらを優先する
+#   - 異常系: --summary 省略 → エラー終了（EXIT_INVALID_ARGS）
+#   - 異常系: --task 省略 かつ 報告書からも解決不能 → エラー終了
+#
+# 実行: bash global-templates/bin/test/maidctl-checkpoint-pass.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAIDCTL_SOURCE="${SCRIPT_DIR}/../maidctl"
+
+pass=0
+fail=0
+
+# --- cmd_checkpoint_pass 関数定義のみを実際の maidctl から抽出 ---
+CMD_FUNC_SRC="$(sed -n '/^cmd_checkpoint_pass() {/,/^}/p' "${MAIDCTL_SOURCE}")"
+if [[ -z "${CMD_FUNC_SRC}" ]]; then
+  echo "FAIL: cmd_checkpoint_pass 関数が ${MAIDCTL_SOURCE} に見つかりません"
+  exit 1
+fi
+
+# --- サンドボックス: 報告書ディレクトリを模擬 ---
+SANDBOX="$(mktemp -d)"
+cleanup() {
+  rm -rf "${SANDBOX}"
+}
+trap cleanup EXIT
+
+REPORT_DIR="${SANDBOX}/.maid-agent/system/data/reports"
+mkdir -p "${REPORT_DIR}"
+
+write_report() {
+  local agent="$1" task_id="$2"
+  cat > "${REPORT_DIR}/current_${agent}.md" <<EOF
+# 作業報告 - テスト
+
+## タスク情報
+- task_id: ${task_id}
+- title: テストタスク
+EOF
+}
+
+# --- 依存スタブ + 抽出した関数を読み込むヘルパー ---
+run_cmd() {
+  # $@ = cmd_checkpoint_pass への引数
+  (
+    EXIT_INVALID_ARGS=5
+    CLAUDE_PROJECT_DIR="${SANDBOX}"
+
+    get_agent_id_from_multiplexer() {
+      [ -n "${STUB_AGENT_ID:-}" ] && { echo "${STUB_AGENT_ID}"; return 0; }
+      return 1
+    }
+
+    api_request() {
+      # $1=method $2=endpoint $3=data
+      echo "CALLED method=$1 endpoint=$2 data=$3" >> "${SANDBOX}/api_calls.log"
+      echo '{"success":true}'
+    }
+
+    eval "${CMD_FUNC_SRC}"
+    cmd_checkpoint_pass "$@"
+  )
+}
+
+assert_exit_ok() {
+  local label="$1"; shift
+  rm -f "${SANDBOX}/api_calls.log"
+  local output exit_code=0
+  output="$(run_cmd "$@" 2>&1)" || exit_code=$?
+  if [[ ${exit_code} -eq 0 ]]; then
+    echo "PASS: ${label}"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: ${label}"
+    echo "  expected: exit 0"
+    echo "  actual:   exit_code=${exit_code}"
+    echo "${output}" | sed 's/^/    /'
+    fail=$((fail + 1))
+  fi
+}
+
+assert_exit_invalid_args() {
+  local label="$1"; shift
+  local output exit_code=0
+  output="$(run_cmd "$@" 2>&1)" || exit_code=$?
+  if [[ ${exit_code} -eq 5 ]] && echo "${output}" | grep -q "エラー"; then
+    echo "PASS: ${label}"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: ${label}"
+    echo "  expected: exit 5 (EXIT_INVALID_ARGS) + エラーメッセージ"
+    echo "  actual:   exit_code=${exit_code}"
+    echo "${output}" | sed 's/^/    /'
+    fail=$((fail + 1))
+  fi
+}
+
+echo "=== maidctl checkpoint pass tests ==="
+echo ""
+
+# -----------------------------------------------------------------------
+# 異常系: --summary 省略 → エラー終了
+# -----------------------------------------------------------------------
+STUB_AGENT_ID="rose"
+write_report rose "task-1454-1"
+assert_exit_invalid_args "--summary 省略 → エラー終了(EXIT_INVALID_ARGS)"
+
+# -----------------------------------------------------------------------
+# 正常系: --task 省略時、報告書から task_id を解決してPATCH
+# -----------------------------------------------------------------------
+STUB_AGENT_ID="rose"
+write_report rose "task-1454-1"
+assert_exit_ok "--task 省略・報告書からtask_id解決 → 正常終了" --summary "暫定判断: dev直接で続行"
+
+if grep -q "endpoint=/api/tasks/1454-1" "${SANDBOX}/api_calls.log" 2>/dev/null \
+  && grep -q '"checkpointPassAdd"' "${SANDBOX}/api_calls.log" 2>/dev/null \
+  && grep -qE '"agentId":[[:space:]]*"rose"' "${SANDBOX}/api_calls.log" 2>/dev/null; then
+  echo "PASS: api_request が期待どおりのPATCH（/api/tasks/1454-1・checkpointPassAdd・agentId=rose）で呼ばれた"
+  pass=$((pass + 1))
+else
+  echo "FAIL: api_request の呼び出し内容が期待と一致しない"
+  cat "${SANDBOX}/api_calls.log" 2>/dev/null | sed 's/^/    /'
+  fail=$((fail + 1))
+fi
+
+# -----------------------------------------------------------------------
+# 正常系: --task 明示時はそちらを優先する
+# -----------------------------------------------------------------------
+STUB_AGENT_ID="rose"
+write_report rose "task-1454-1"
+rm -f "${SANDBOX}/api_calls.log"
+run_cmd --summary "明示タスク指定" --task task-9999 >/dev/null 2>&1
+if grep -q "endpoint=/api/tasks/9999" "${SANDBOX}/api_calls.log" 2>/dev/null; then
+  echo "PASS: --task 明示時は報告書のtask_idより優先される"
+  pass=$((pass + 1))
+else
+  echo "FAIL: --task 明示が優先されなかった"
+  cat "${SANDBOX}/api_calls.log" 2>/dev/null | sed 's/^/    /'
+  fail=$((fail + 1))
+fi
+
+# -----------------------------------------------------------------------
+# 異常系: --task 省略 かつ 報告書が存在しない → エラー終了
+# -----------------------------------------------------------------------
+STUB_AGENT_ID="alice"
+rm -f "${REPORT_DIR}/current_alice.md"
+assert_exit_invalid_args "--task 省略・報告書なし → エラー終了(EXIT_INVALID_ARGS)" --summary "報告書なしケース"
+
+echo ""
+echo "Results: ${pass} passed, ${fail} failed"
+[[ ${fail} -eq 0 ]]

--- a/global-templates/maid-agent-messenger/dist/routes/task-api-routes.js
+++ b/global-templates/maid-agent-messenger/dist/routes/task-api-routes.js
@@ -90,7 +90,9 @@ export function createTaskApiRoutes(deps = {}) {
             // V2.1 拡張フィールド
             mainStatus, subStatus, type, size, tentative, blockedBy, artifacts, artifactAdd, reviewStatus, 
             // V2.1 追加フィールド
-            archived, actionRequired, } = req.body;
+            archived, actionRequired, 
+            // C-1: Type B（通過型チェックポイント）記録
+            checkpointPassAdd, } = req.body;
             if (description && typeof description === "string" && description.length > VALIDATION.MAX_DESCRIPTION_LENGTH) {
                 res.status(400).json({
                     error: `description が上限文字数（${VALIDATION.MAX_DESCRIPTION_LENGTH}文字）を超えています`,
@@ -120,6 +122,8 @@ export function createTaskApiRoutes(deps = {}) {
                 // V2.1 追加
                 archived,
                 actionRequired,
+                // C-1: Type B（通過型チェックポイント）記録
+                checkpointPassAdd,
             });
             if (!result.success) {
                 const errorMessage = result.error || "Task not found";

--- a/global-templates/maid-agent-messenger/dist/services/task-crud-update.js
+++ b/global-templates/maid-agent-messenger/dist/services/task-crud-update.js
@@ -227,6 +227,16 @@ export async function executeUpdateTask(projectPath, params) {
         if (params.escalation !== undefined) {
             task.escalation = params.escalation;
         }
+        if (params.checkpointPassAdd !== undefined) {
+            if (!task.checkpointPassed) {
+                task.checkpointPassed = [];
+            }
+            task.checkpointPassed.push({
+                timestamp: now,
+                summary: params.checkpointPassAdd.summary,
+                agentId: params.checkpointPassAdd.agentId,
+            });
+        }
         // 最終更新日時を自動設定
         task.updatedAt = now;
         const result = { success: true, task };

--- a/packages/maid-agent-messenger/src/__tests__/routes/task-api-routes.e2e.test.ts
+++ b/packages/maid-agent-messenger/src/__tests__/routes/task-api-routes.e2e.test.ts
@@ -242,6 +242,25 @@ describe("PATCH /api/tasks/:id", () => {
 
     expect(res.body.error).toBe("Task update failed");
   });
+
+  it("checkpointPassAdd を executeUpdateTask に転送する（C-1）", async () => {
+    const updatedTask = createMockTask({ id: "1454", status: "working" });
+    mockExecuteUpdateTask.mockResolvedValue({ success: true, task: updatedTask });
+
+    const res = await supertest(app)
+      .patch("/api/tasks/1454")
+      .send({ checkpointPassAdd: { summary: "暫定判断: dev直接で続行", agentId: "rose" } })
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(mockExecuteUpdateTask).toHaveBeenCalledWith(
+      TEST_PROJECT_PATH,
+      expect.objectContaining({
+        taskId: "1454",
+        checkpointPassAdd: { summary: "暫定判断: dev直接で続行", agentId: "rose" },
+      }),
+    );
+  });
 });
 
 // ===========================================

--- a/packages/maid-agent-messenger/src/__tests__/services/task-crud-update-checkpoint-pass.test.ts
+++ b/packages/maid-agent-messenger/src/__tests__/services/task-crud-update-checkpoint-pass.test.ts
@@ -1,0 +1,143 @@
+/**
+ * task-crud-update: checkpointPassAdd（C-1: Type B 通過型チェックポイント記録）テスト
+ *
+ * 目的: `maidctl checkpoint pass --summary "..."` が呼び出す
+ * executeUpdateTask({ checkpointPassAdd }) が、対象タスクの checkpointPassed
+ * 配列にタイムスタンプ付きで正しく追記されることを確認する。
+ */
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+
+// ESMモード: jest.unstable_mockModule + dynamic import パターン（beforeEach 内での重いモジュール再インポートは行わない）
+const mockWithTasksLock = jest.fn<any>();
+
+jest.unstable_mockModule("../../services/task-core.js", () => ({
+  withTasksLock: mockWithTasksLock,
+}));
+
+jest.unstable_mockModule("../../services/task-side-effects.js", () => ({
+  executeSideEffects: jest.fn<any>().mockResolvedValue({}),
+}));
+
+jest.unstable_mockModule("../../services/task-migration.js", () => ({
+  getAgentRole: jest.fn<any>().mockReturnValue("maid"),
+  validateStatusTransition: jest.fn<any>().mockReturnValue({ valid: true }),
+}));
+
+jest.unstable_mockModule("../../services/task-auto-close.js", () => ({
+  checkAndAutoCloseParent: jest.fn<any>().mockResolvedValue({ autoClosedIds: [] }),
+  resolveBlockedTasks: jest.fn<any>().mockResolvedValue({ unblockedTasks: [] }),
+}));
+
+jest.unstable_mockModule("../../utils/yaml-helper.js", () => ({
+  getTimestamp: () => "2026-07-04T13:00:00+09:00",
+  getJstTimestamp: () => "2026-07-04 13:00:00",
+}));
+
+const { executeUpdateTask } = await import("../../services/task-crud-update.js");
+
+const PROJECT_PATH = "/project";
+
+function createMockTasksData(task: Record<string, unknown>) {
+  return {
+    lastTaskNumber: 1,
+    tasks: [
+      {
+        id: "task-1454-1",
+        parentId: null,
+        title: "テストタスク",
+        description: "",
+        priority: "medium" as const,
+        status: "working" as const,
+        substatus: "working" as const,
+        subStatus: "working" as const,
+        mainStatus: "open" as const,
+        category: "task" as const,
+        type: "work" as const,
+        targetPath: null,
+        assignees: [],
+        createdAt: "2026-07-04T00:00:00+09:00",
+        updatedAt: "2026-07-04T00:00:00+09:00",
+        assignedAt: "2026-07-04T00:00:00+09:00",
+        startedAt: "2026-07-04T00:00:00+09:00",
+        completedAt: null,
+        reportPaths: [],
+        summary: null,
+        blockedBy: [],
+        actionRequired: false,
+        actionRequiredAt: null,
+        archived: false,
+        archivedAt: null,
+        artifacts: [],
+        escalation: undefined,
+        stepRequired: false,
+        ...task,
+      },
+    ],
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockWithTasksLock.mockImplementation(async (_projectPath: string, operation: any) => {
+    const data = createMockTasksData({});
+    const { result } = await operation(data);
+    return result;
+  });
+});
+
+describe("executeUpdateTask - checkpointPassAdd（C-1）", () => {
+  it("checkpointPassed が未初期化のタスクに新規配列を作って1件追記する", async () => {
+    const result = await executeUpdateTask(PROJECT_PATH, {
+      taskId: "task-1454-1",
+      checkpointPassAdd: { summary: "暫定判断: dev直接で続行", agentId: "rose" },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.task?.checkpointPassed).toEqual([
+      { timestamp: "2026-07-04T13:00:00+09:00", summary: "暫定判断: dev直接で続行", agentId: "rose" },
+    ]);
+  });
+
+  it("既存の checkpointPassed に追記する（既存エントリを保持）", async () => {
+    mockWithTasksLock.mockImplementation(async (_projectPath: string, operation: any) => {
+      const data = createMockTasksData({
+        checkpointPassed: [
+          { timestamp: "2026-07-01T00:00:00+09:00", summary: "1件目", agentId: "emma" },
+        ],
+      });
+      const { result } = await operation(data);
+      return result;
+    });
+
+    const result = await executeUpdateTask(PROJECT_PATH, {
+      taskId: "task-1454-1",
+      checkpointPassAdd: { summary: "2件目", agentId: "rose" },
+    });
+
+    expect(result.task?.checkpointPassed).toEqual([
+      { timestamp: "2026-07-01T00:00:00+09:00", summary: "1件目", agentId: "emma" },
+      { timestamp: "2026-07-04T13:00:00+09:00", summary: "2件目", agentId: "rose" },
+    ]);
+  });
+
+  it("checkpointPassAdd を指定しない通常更新では checkpointPassed を変更しない", async () => {
+    mockWithTasksLock.mockImplementation(async (_projectPath: string, operation: any) => {
+      const data = createMockTasksData({
+        checkpointPassed: [
+          { timestamp: "2026-07-01T00:00:00+09:00", summary: "既存記録", agentId: "emma" },
+        ],
+      });
+      const { result } = await operation(data);
+      return result;
+    });
+
+    const result = await executeUpdateTask(PROJECT_PATH, {
+      taskId: "task-1454-1",
+      summary: "通常のサマリ更新",
+    });
+
+    expect(result.task?.checkpointPassed).toEqual([
+      { timestamp: "2026-07-01T00:00:00+09:00", summary: "既存記録", agentId: "emma" },
+    ]);
+  });
+});

--- a/packages/maid-agent-messenger/src/routes/task-api-routes.ts
+++ b/packages/maid-agent-messenger/src/routes/task-api-routes.ts
@@ -127,6 +127,8 @@ router.patch("/api/tasks/:id", async (req: Request, res: Response) => {
       blockedBy, artifacts, artifactAdd, reviewStatus,
       // V2.1 追加フィールド
       archived, actionRequired,
+      // C-1: Type B（通過型チェックポイント）記録
+      checkpointPassAdd,
     } = req.body;
 
     if (description && typeof description === "string" && description.length > VALIDATION.MAX_DESCRIPTION_LENGTH) {
@@ -159,6 +161,8 @@ router.patch("/api/tasks/:id", async (req: Request, res: Response) => {
       // V2.1 追加
       archived,
       actionRequired,
+      // C-1: Type B（通過型チェックポイント）記録
+      checkpointPassAdd,
     });
 
     if (!result.success) {

--- a/packages/maid-agent-messenger/src/services/task-crud-update.ts
+++ b/packages/maid-agent-messenger/src/services/task-crud-update.ts
@@ -252,6 +252,16 @@ export async function executeUpdateTask(
     if (params.escalation !== undefined) {
       task.escalation = params.escalation;
     }
+    if (params.checkpointPassAdd !== undefined) {
+      if (!task.checkpointPassed) {
+        task.checkpointPassed = [];
+      }
+      task.checkpointPassed.push({
+        timestamp: now,
+        summary: params.checkpointPassAdd.summary,
+        agentId: params.checkpointPassAdd.agentId,
+      });
+    }
 
     // 最終更新日時を自動設定
     task.updatedAt = now;

--- a/packages/types/src/task.ts
+++ b/packages/types/src/task.ts
@@ -61,6 +61,13 @@ export interface EscalationInfo {
   detail?: string; // 詳細・背景（省略可）
 }
 
+// C-1: Type B（通過型チェックポイント）記録エントリ
+export interface CheckpointPassEntry {
+  timestamp: string; // 記録日時
+  summary: string; // 暫定判断の内容と根拠
+  agentId: string; // 記録したエージェントID
+}
+
 export type TaskCategory = "task" | "skill_candidate" | "improvement";
 
 export interface Assignee {
@@ -109,6 +116,9 @@ export interface Task {
 
   // === V2.1: エスカレーション情報 ===
   escalation?: EscalationInfo; // エスカレーション情報（checkpoint時）
+
+  // === C-1: Type B（通過型チェックポイント）記録 ===
+  checkpointPassed?: CheckpointPassEntry[]; // 通過型チェックポイントの記録一覧
 }
 
 /**
@@ -163,6 +173,9 @@ export interface UpdateTaskParams {
 
   // === V2.1: エスカレーション情報 ===
   escalation?: EscalationInfo; // エスカレーション情報（checkpoint時）
+
+  // === C-1: Type B（通過型チェックポイント）記録 ===
+  checkpointPassAdd?: { summary: string; agentId: string }; // 通過型チェックポイント記録追加（timestampはサーバー側で付与）
 }
 
 export interface SideEffectResults {

--- a/project-templates/core/.claude/skills/maidctl-reference/SKILL.md
+++ b/project-templates/core/.claude/skills/maidctl-reference/SKILL.md
@@ -68,6 +68,7 @@ maidctl CLI v2.1.0 の詳細リファレンス。コマンド一覧、オプシ�
 |---------------|---------------|------|
 | `maidctl get my-task` | `my-task` | 自分のタスク取得 |
 | `maidctl set my-status STATUS` | `my-status` | ステータス更新（V2.1対応） |
+| `maidctl checkpoint pass --summary "..."` | （新規・旧なし） | Type B（通過型チェックポイント）記録（C-1・task-1454-1） |
 
 #### チーム状態・レポート
 
@@ -192,6 +193,23 @@ maidctl set my-status blocked --substatus waiting --blocked-by 310-1-1
 
 # 完了
 maidctl set my-status completed
+```
+
+#### Type A（停止型）vs Type B（通過型）チェックポイント
+
+| | Type A（停止型） | Type B（通過型） |
+|---|---|---|
+| コマンド | `maidctl set my-status blocked --substatus checkpoint --reason "..."` | `maidctl checkpoint pass --summary "..."` |
+| 状態遷移 | あり（`blocked`へ遷移し作業停止） | なし（作業を止めずに記録のみ） |
+| 用途 | 上位者の判断が出るまで作業を進められない場合 | 暫定判断で作業を継続しつつ、判断内容と根拠を事後確認用に記録したい場合 |
+| 記録先 | タスクの `escalation` フィールド | タスクの `checkpointPassed` 配列（追記型） |
+
+```bash
+# Type B: 作業を止めずに暫定判断を記録（対象は現在のmy-task）
+maidctl checkpoint pass --summary "暫定判断: 別リポジトリで実装のため所定のfeatureブランチ+PRフローで対応"
+
+# Type B: 対象タスクを明示
+maidctl checkpoint pass --summary "..." --task task-1454-1
 ```
 
 #### --action-required フラグ（set task / set my-status 共通）


### PR DESCRIPTION
## 概要

task-1454-1（C-1）。Type B（通過型チェックポイント）を記録する新動詞 `maidctl checkpoint pass --summary "..."` を追加。

既存の `maidctl set my-status blocked --substatus checkpoint`（Type A・停止型）は状態遷移（作業停止・上位者の判断待ち）を伴うが、Type Bは状態遷移を伴わない純粋な記録操作。作業を止めずに暫定判断の内容と根拠を記録し、事後確認待ちとして対象タスクに積む。

## ソース位置についての補足

タスクのご指示では maidctl ソースを `.maid-agent/system/bin/` としていましたが、実際には本リポジトリ（MaidAgentController）の `global-templates/bin/maidctl` が真の source of truth で、`~/.maid-agent/bin/maidctl` へ配布される構成でした（`.maid-agent/system/bin/` には別のシェルスクリプト群のみ存在）。本リポジトリは実在のgitリポジトリのため、`one-work-one-feature-branch` ルールに従いfeatureブランチ+PRで対応しています。

## 実装内容

- `packages/types/src/task.ts`: `CheckpointPassEntry`型を新設。`Task.checkpointPassed`（記録配列）・`UpdateTaskParams.checkpointPassAdd`（追記パラメータ）を追加
- `packages/maid-agent-messenger/src/services/task-crud-update.ts`: 既存の `artifactAdd` と同じ「配列へpush」パターンで `checkpointPassAdd` を処理（timestampはサーバー側で付与）
- `packages/maid-agent-messenger/src/routes/task-api-routes.ts`: `PATCH /api/tasks/:id` で `checkpointPassAdd` を受け付け
- `global-templates/bin/maidctl`: `cmd_checkpoint_pass()` を新設。`--summary` 必須・`--task` 省略時は現在の my-task 報告書から task_id を解決
- `project-templates/core/.claude/skills/maidctl-reference/SKILL.md`: Type A/B の使い分け表とコマンド例を追記

## テスト

- `task-crud-update-checkpoint-pass.test.ts`（新規）: 配列新規作成・既存配列への追記・非対象時の非破壊を確認
- `task-api-routes.e2e.test.ts`（追記）: `checkpointPassAdd` が `executeUpdateTask` へ正しく転送されることを確認
- `global-templates/bin/test/maidctl-checkpoint-pass.test.sh`（新規）: `cmd_checkpoint_pass` を実際の maidctl から関数抽出し、依存（`api_request`/`get_agent_id_from_multiplexer`）をスタブして検証
  - `--summary` 省略 → エラー終了
  - `--task` 省略時、報告書から task_id 解決 → 正常終了・期待どおりのPATCH
  - `--task` 明示時は報告書より優先
  - `--task` 省略かつ報告書もない → エラー終了

```
$ bash global-templates/bin/test/maidctl-checkpoint-pass.test.sh
Results: 5 passed, 0 failed
```

messenger パッケージの既存テストスイート全体（500件）も実行し、無関係な `notification-api-routes.test.ts` の2件（`/tmp` パス依存・タイムアウト。本PRの変更と無関係）を除き全てpassすることを確認しました。

## 未実施（レビュー後の判断待ち）

本番の `maid-agent-messenger` は pm2 cluster モードで全エージェント共有稼働中のため、レビュー・マージ前の反映・再起動は行っていません。マージ後、`npm run build`（postbuild で `global-templates/` へ自動sync）→ 配布先 `~/.maid-agent/` への反映 → `pm2 restart maid-agent-messenger` が必要です。

## Test plan

- [x] `packages/types` / `packages/maid-agent-messenger` の `npm run build` 通過
- [x] messenger 既存テストスイート回帰確認（無関係な2件を除き全pass）
- [x] 新規Jestテスト（サービス層+ルート層）全pass
- [x] 新規bashテスト（CLI引数検証+タスクID解決ロジック）全pass
- [x] `bash -n global-templates/bin/maidctl` シンタックスOK

🤖 Generated with [Claude Code](https://claude.com/claude-code)