### PR TITLE
maidctl task list: actionRequiredフィルタ+未知オプションエラー化 (task-1495-1)

### DIFF
--- a/global-templates/bin/maidctl
+++ b/global-templates/bin/maidctl
@@ -432,6 +432,7 @@ cmd_task_list() {
       --assignee) query="${query}&assignee=$2"; shift 2 ;;
       --parent) query="${query}&parentId=$2"; shift 2 ;;
       --limit) query="${query}&limit=$2"; shift 2 ;;
+      --action-required) query="${query}&actionRequired=true"; shift ;;
       --summary) summary=true; shift ;;
       --json) json_output=true; shift ;;
       --help|-h)
@@ -442,11 +443,16 @@ cmd_task_list() {
         echo "  --assignee AGENT  担当者でフィルタ"
         echo "  --parent ID       親タスクIDでフィルタ"
         echo "  --limit N         取得件数上限"
+        echo "  --action-required 要対応(🚨)フラグが立っているタスクのみ"
         echo "  --summary         軽量版レスポンス"
         echo "  --json            JSON出力"
         return 0
         ;;
-      *) shift ;;
+      *)
+        echo "エラー: 不明なオプション: $1" >&2
+        echo "  -h/--help でオプション一覧を確認できます" >&2
+        exit $EXIT_INVALID_ARGS
+        ;;
     esac
   done
 

--- a/global-templates/bin/test/maidctl-task-list-action-required.test.sh
+++ b/global-templates/bin/test/maidctl-task-list-action-required.test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# maidctl task list --action-required / 未知オプションエラー化テスト（task-1495-1）
+#
+# 背景: task-1494-3(may)の改善提案の実装。cmd_task_list は --status/--assignee/--parent/
+# --limit/--summary/--json のみ対応しており、actionRequired（🚨要対応フラグ）での絞り込み
+# 手段が無く、未知オプション（例: 存在しない --step-required）を指定してもサイレントに
+# 無視され「フィルタなし全件」が返っていた（実害: 執事がstepRequired 52件という誤った
+# 棚卸し結果を掴んだ）。本テストは以下2点を検証する:
+#   (1) --action-required 指定時、api_request に actionRequired=true クエリが渡る
+#   (2) 未知オプション指定時、cmd_task_get/set task と同様にエラー終了する
+#     （api_request が一度も呼ばれないこと＝フィルタなし全件取得を防止）
+#
+# 完了条件:
+#   - 正常系: --action-required → クエリに actionRequired=true が含まれる
+#   - 正常系: --action-required 省略時はクエリに actionRequired が含まれない（既存挙動維持）
+#   - 正常系: 既存オプション（--status 等）との併用でも actionRequired=true が含まれる
+#   - 異常系: 未知オプション（例: --step-required）→ エラー終了(EXIT_INVALID_ARGS) かつ
+#     api_request が呼ばれない
+#
+# 実行: bash global-templates/bin/test/maidctl-task-list-action-required.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAIDCTL_SOURCE="${SCRIPT_DIR}/../maidctl"
+
+pass=0
+fail=0
+
+# --- cmd_task_list 関数定義のみを実際の maidctl から抽出 ---
+CMD_FUNC_SRC="$(sed -n '/^cmd_task_list() {/,/^}/p' "${MAIDCTL_SOURCE}")"
+if [[ -z "${CMD_FUNC_SRC}" ]]; then
+  echo "FAIL: cmd_task_list 関数が ${MAIDCTL_SOURCE} に見つかりません"
+  exit 1
+fi
+
+# --- 依存スタブ + 抽出した関数を読み込むヘルパー ---
+CALL_LOG=""
+run_cmd() {
+  # $@ = cmd_task_list への引数
+  (
+    EXIT_INVALID_ARGS=5
+    CALL_LOG_FILE="${CALL_LOG}"
+
+    api_request() {
+      # $1=method $2=endpoint
+      echo "CALLED method=$1 endpoint=$2" >> "${CALL_LOG_FILE}"
+      echo '{"tasks":[],"total":0,"hasMore":false}'
+    }
+
+    format_task_list() {
+      echo "FORMATTED"
+    }
+
+    eval "${CMD_FUNC_SRC}"
+    cmd_task_list "$@"
+  )
+}
+
+setup_log() {
+  CALL_LOG="$(mktemp)"
+}
+
+assert_query_contains() {
+  local label="$1" needle="$2"; shift 2
+  setup_log
+  run_cmd "$@" >/dev/null 2>&1
+  if grep -q "${needle}" "${CALL_LOG}"; then
+    echo "PASS: ${label}"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: ${label}"
+    echo "  expected query to contain: ${needle}"
+    echo "  actual call log:"
+    cat "${CALL_LOG}" | sed 's/^/    /'
+    fail=$((fail + 1))
+  fi
+  rm -f "${CALL_LOG}"
+}
+
+assert_query_not_contains() {
+  local label="$1" needle="$2"; shift 2
+  setup_log
+  run_cmd "$@" >/dev/null 2>&1
+  if grep -q "${needle}" "${CALL_LOG}"; then
+    echo "FAIL: ${label}"
+    echo "  expected query NOT to contain: ${needle}"
+    echo "  actual call log:"
+    cat "${CALL_LOG}" | sed 's/^/    /'
+    fail=$((fail + 1))
+  else
+    echo "PASS: ${label}"
+    pass=$((pass + 1))
+  fi
+  rm -f "${CALL_LOG}"
+}
+
+assert_unknown_option_errors() {
+  local label="$1"; shift
+  setup_log
+  local output exit_code=0
+  output="$(run_cmd "$@" 2>&1)" || exit_code=$?
+  local api_called="no"
+  [[ -s "${CALL_LOG}" ]] && api_called="yes"
+  if [[ ${exit_code} -eq 5 ]] && echo "${output}" | grep -q "エラー" && [[ "${api_called}" == "no" ]]; then
+    echo "PASS: ${label}"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: ${label}"
+    echo "  expected: exit 5 (EXIT_INVALID_ARGS) + エラーメッセージ + api_request未呼び出し"
+    echo "  actual:   exit_code=${exit_code} api_called=${api_called}"
+    echo "${output}" | sed 's/^/    /'
+    fail=$((fail + 1))
+  fi
+  rm -f "${CALL_LOG}"
+}
+
+echo "=== maidctl task list --action-required / 未知オプションエラー化テスト ==="
+echo ""
+
+# -----------------------------------------------------------------------
+# 正常系: --action-required 指定 → actionRequired=true がクエリに含まれる
+# -----------------------------------------------------------------------
+assert_query_contains "--action-required 指定 → actionRequired=trueがクエリに含まれる" \
+  "endpoint=/api/tasks?actionRequired=true" --action-required --json
+
+# -----------------------------------------------------------------------
+# 正常系: --action-required 省略時は actionRequired がクエリに含まれない（既存挙動維持）
+# -----------------------------------------------------------------------
+assert_query_not_contains "--action-required 省略時はactionRequiredを含まない" \
+  "actionRequired" --status completed --json
+
+# -----------------------------------------------------------------------
+# 正常系: 既存オプションとの併用でも actionRequired=true が含まれる
+# -----------------------------------------------------------------------
+assert_query_contains "--status との併用でも actionRequired=true が含まれる" \
+  "actionRequired=true" --status completed --action-required --json
+
+# -----------------------------------------------------------------------
+# 異常系: 未知オプション → エラー終了・api_request未呼び出し（サイレント無視の再発防止）
+# -----------------------------------------------------------------------
+assert_unknown_option_errors "未知オプション --step-required → エラー終了・全件取得を防止" \
+  --step-required --summary
+
+assert_unknown_option_errors "未知オプション --foo → エラー終了" \
+  --foo bar
+
+echo ""
+echo "Results: ${pass} passed, ${fail} failed"
+[[ ${fail} -eq 0 ]]

--- a/packages/maid-agent-messenger/src/__tests__/routes/task-api-routes.e2e.test.ts
+++ b/packages/maid-agent-messenger/src/__tests__/routes/task-api-routes.e2e.test.ts
@@ -145,6 +145,39 @@ describe("GET /api/tasks", () => {
     );
   });
 
+  it("actionRequired=trueフィルタを正しくパースする（task-1494-3改善提案）", async () => {
+    mockExecuteListTasks.mockResolvedValue(createMockListResponse());
+
+    await supertest(app).get("/api/tasks?actionRequired=true").expect(200);
+
+    expect(mockExecuteListTasks).toHaveBeenCalledWith(
+      TEST_PROJECT_PATH,
+      expect.objectContaining({ actionRequired: true }),
+    );
+  });
+
+  it("actionRequired=falseフィルタを正しくパースする", async () => {
+    mockExecuteListTasks.mockResolvedValue(createMockListResponse());
+
+    await supertest(app).get("/api/tasks?actionRequired=false").expect(200);
+
+    expect(mockExecuteListTasks).toHaveBeenCalledWith(
+      TEST_PROJECT_PATH,
+      expect.objectContaining({ actionRequired: false }),
+    );
+  });
+
+  it("actionRequired未指定時はフィルタを渡さない", async () => {
+    mockExecuteListTasks.mockResolvedValue(createMockListResponse());
+
+    await supertest(app).get("/api/tasks").expect(200);
+
+    expect(mockExecuteListTasks).toHaveBeenCalledWith(
+      TEST_PROJECT_PATH,
+      expect.not.objectContaining({ actionRequired: expect.anything() }),
+    );
+  });
+
   it("サービスエラー時に500を返す", async () => {
     mockExecuteListTasks.mockRejectedValue(new Error("DB error"));
 

--- a/packages/maid-agent-messenger/src/routes/task-api-routes.ts
+++ b/packages/maid-agent-messenger/src/routes/task-api-routes.ts
@@ -49,6 +49,7 @@ router.get("/api/tasks", async (req: Request, res: Response) => {
       sortField?: "createdAt" | "priority" | "status" | "id";
       sortOrder?: "asc" | "desc";
       summaryOnly?: boolean;
+      actionRequired?: boolean;
     } = {};
 
     if (req.query.status) {
@@ -78,6 +79,9 @@ router.get("/api/tasks", async (req: Request, res: Response) => {
     }
     if (req.query.summary === "true") {
       filter.summaryOnly = true;
+    }
+    if (req.query.actionRequired !== undefined) {
+      filter.actionRequired = req.query.actionRequired === "true";
     }
 
     const result = await executeListTasks(projectPath, filter);
@@ -257,7 +261,7 @@ router.post("/api/tasks/:id/rearchive", async (req: Request, res: Response) => {
     // 対象エージェントを特定
     const targetAgentIds = agentId
       ? [agentId]
-      : task.assignees.map((a) => a.agentId);
+      : task.assignees.map((a: { agentId: string }) => a.agentId);
 
     for (const agent of targetAgentIds) {
       const result = await archiveReport(

--- a/project-templates/core/.claude/skills/maidctl-reference/resources/reference/options.md
+++ b/project-templates/core/.claude/skills/maidctl-reference/resources/reference/options.md
@@ -34,8 +34,11 @@ maidctl の各コマンドで使用できるオプションの詳細リファレ
 | `--parent ID` | | 親タスクIDフィルタ | `--parent 077` |
 | `--category CAT` | `-c` | カテゴリフィルタ | `--category skill_candidate` |
 | `--limit N` | `-l` | 取得件数上限 | `--limit 10` |
+| `--action-required` | | 要対応(🚨)フラグが立っているタスクのみに絞り込む（task-1495-1で追加） | `--action-required` |
 | `--summary` | `-m` | 軽量版 | - |
 | `--json` | | JSON出力 | - |
+
+> ⚠️ 未知のオプションを指定した場合はエラー終了する（`エラー: 不明なオプション: --xxx`）。以前はサイレントに無視され「フィルタなし全件」が返っていた（task-1494-3 参照）。
 
 ---
 


### PR DESCRIPTION
## Summary
- task-1494-3(may)の改善提案の実装。`cmd_task_list`（`maidctl get tasks`）が `--status`/`--assignee`/`--parent`/`--limit`/`--summary`/`--json` 以外の未知オプションをサイレントに無視し「フィルタなし全件」を返していた問題を修正
- `maidctl get tasks --action-required` フィルタを新規追加（サービス層 `executeListTasks` は既に `actionRequired` フィルタに対応済みだったため、ルート層(`GET /api/tasks`)の未接続のみが原因だった）
- 未知オプション指定時は `task get`/`set task` と同様に `エラー: 不明なオプション: --xxx` を出力してエラー終了(EXIT_INVALID_ARGS)するよう変更
- ついでに: 同ファイル(`task-api-routes.ts`)の既存のTS7006型エラー(`task.assignees.map((a) => ...)` の暗黙any)がテスト実行をブロックしていたため、明示的な型注釈を追加して解消（pre-existing・本PRのスコープに必要な最小修正）
- `maidctl-reference` スキルの `options.md` に `--action-required` オプションを追記

## 実害（背景）
執事が `maidctl get tasks --step-required --summary`（存在しないオプション）を実行した際、エラーにならず全1736件が返り、「stepRequiredフラグ52件」という誤った棚卸し結果に繋がった（task-1494-3）。

## Test plan
- [x] TDD: 先にテストを追加し失敗(RED)を確認してからコミット、実装後に成功(GREEN)を確認
- [x] `packages/maid-agent-messenger`: jestテスト追加（`actionRequired=true/false`パース・未指定時の非包含を検証）
- [x] `global-templates/bin/test/maidctl-task-list-action-required.test.sh`（新規）: `--action-required`フィルタ・未知オプションのエラー終了・api_request未呼び出しを検証
- [x] 既存シェルテスト2件（`maidctl-assign-task-warning.test.sh`, `maidctl-checkpoint-pass.test.sh`）回帰なし
- [x] `npm run build`(`tsc --noEmit`) 通過
- [x] `packages/maid-agent-messenger` 全jestテスト実行（507件中505件パス。残り2件は`notification-api-routes.test.ts`の`/tmp`パス依存・タイムアウトで、本PR差分と無関係・originダブdevでも同一失敗を確認済みのpre-existing事象）
- [ ] 実機確認（マージ後、`maidctl get tasks --action-required --summary` で🚨要対応タスクのみ返ることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)