### PR TITLE
notification-api-routesテストの実配信防止（execモック化+dist二重実行防御）(task-1495-3)

### DIFF
--- a/packages/maid-agent-messenger/jest.config.js
+++ b/packages/maid-agent-messenger/jest.config.js
@@ -16,6 +16,9 @@ export default {
     ],
   },
   testMatch: ["**/__tests__/**/*.test.ts"],
+  // dist/ にはビルド成果物として __tests__ の .js 版が生成される（testMatch は拡張子で
+  // 除外されるが、二重実行防止の多重防御として明示的にも除外する。task-1495-3）
+  testPathIgnorePatterns: ["/node_modules/", "/dist/"],
   collectCoverageFrom: ["src/**/*.ts", "!src/**/*.d.ts"],
   coverageDirectory: "coverage",
   verbose: true,

--- a/packages/maid-agent-messenger/src/__tests__/routes/notification-api-routes.test.ts
+++ b/packages/maid-agent-messenger/src/__tests__/routes/notification-api-routes.test.ts
@@ -1,12 +1,19 @@
 /**
  * notification-api-routes テスト
  * POST /api/notifications エンドポイントのユニットテスト
+ *
+ * task-1495-3: sendToAgent() が child_process.exec 経由で本物の `maidctl notify` を
+ * 子プロセス実行しており、モック化されていなかったため npm test のたびに全エージェントへ
+ * 実通知がブロードキャストされる事故が発生していた。util.promisify.custom を使い、
+ * exec を完全にスタブ化することで実プロセス起動を排除する（live-service-isolated-testing
+ * スキルの原則: 稼働中サービスに実際のコマンドを到達させない）。
  */
 
 import { jest, describe, it, expect, beforeEach, afterAll } from "@jest/globals";
 import * as os from "os";
 import * as path from "path";
 import * as fs from "fs/promises";
+import { promisify } from "util";
 
 // テスト用の一時ディレクトリ
 const TEST_PROJECT_PATH = path.join(os.tmpdir(), "test-notification-api");
@@ -15,7 +22,19 @@ const HISTORY_LOG_PATH = path.join(
   ".maid-agent/system/data/notifications/history.log"
 );
 
-// ルーターをダイナミックインポート
+// --- child_process.exec のスタブ化 ---
+// sendToAgent() は `promisify(exec)` を使うため、util.promisify.custom を実装した
+// スタブに差し替える（Node組み込みのexecも同様にpromisify.customを実装しており、
+// これがないと promisify() が「コールバック形式」とみなし実引数がズレて壊れる）。
+const mockExecImpl = jest.fn<(command: string, options?: unknown) => Promise<{ stdout: string; stderr: string }>>();
+const mockExec = jest.fn() as unknown as { [key: symbol]: typeof mockExecImpl };
+mockExec[promisify.custom] = mockExecImpl;
+
+jest.unstable_mockModule("child_process", () => ({
+  exec: mockExec,
+}));
+
+// ルーターをダイナミックインポート（モック定義の後に行うこと）
 const notificationApiRoutes = (await import("../../routes/notification-api-routes.js")).default;
 
 // Express req/res モック
@@ -60,6 +79,10 @@ describe("POST /api/notifications", () => {
       // 存在しない場合は無視
     }
     await fs.mkdir(path.dirname(HISTORY_LOG_PATH), { recursive: true });
+
+    // exec モックをリセットし、デフォルトは成功（本物のプロセスは一切起動しない）
+    mockExecImpl.mockReset();
+    mockExecImpl.mockResolvedValue({ stdout: "", stderr: "" });
   });
 
   afterAll(async () => {
@@ -116,7 +139,7 @@ describe("POST /api/notifications", () => {
     );
   });
 
-  it("有効なリクエストでhistory.logに追記される", async () => {
+  it("有効なリクエストで通知コマンドが実行される（実プロセスは起動しない）", async () => {
     const { req, res } = createMockReqRes(
       { project: TEST_PROJECT_PATH },
       { to: "chief", message: "テストメッセージ" }
@@ -135,12 +158,36 @@ describe("POST /api/notifications", () => {
       })
     );
 
-    // ファイルに追記されていることを確認
+    // 実プロセスではなくモックされた exec が、期待どおりのコマンドで呼ばれたことを確認する
+    expect(mockExecImpl).toHaveBeenCalledTimes(1);
+    const [command, options] = mockExecImpl.mock.calls[0] as [string, { cwd?: string }];
+    expect(command).toBe('maidctl notify --from master chief "テストメッセージ"');
+    expect(options).toEqual(expect.objectContaining({ cwd: TEST_PROJECT_PATH }));
+  });
+
+  it("通知コマンドが失敗した場合、history.logへフォールバック書き込みされ失敗レスポンスを返す", async () => {
+    mockExecImpl.mockRejectedValueOnce(new Error("maidctl: command not found"));
+
+    const { req, res } = createMockReqRes(
+      { project: TEST_PROJECT_PATH },
+      { to: "chief", message: "テストメッセージ" }
+    );
+    await postHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: "Failed to send message to agent: chief",
+      })
+    );
+
+    // フォールバックとしてローカルのhistory.logに追記されていることを確認
     const content = await fs.readFile(HISTORY_LOG_PATH, "utf-8");
     expect(content).toContain("master → chief: テストメッセージ");
   });
 
-  it("複数のターゲットに送信できる", async () => {
+  it("複数のターゲットに送信できる（実プロセスは一度も起動しない）", async () => {
     const validTargets = ["butler", "chief", "emma", "sophia", "lily", "rose", "alice", "may", "flora", "luna"];
 
     for (const target of validTargets) {
@@ -157,6 +204,13 @@ describe("POST /api/notifications", () => {
           }),
         })
       );
+    }
+
+    // 10ターゲット分すべてモックのexecが呼ばれ、本物のプロセスは一切起動していないことを確認
+    expect(mockExecImpl).toHaveBeenCalledTimes(validTargets.length);
+    for (const call of mockExecImpl.mock.calls) {
+      const [command] = call as [string];
+      expect(command).toMatch(/^maidctl notify --from master \w+ "Message to \w+"$/);
     }
   });
 


### PR DESCRIPTION
## Summary
- `npm test` 実行のたびに `notification-api-routes.test.ts`「複数のターゲットに送信できる」等のテストが、モックなしでPOSTハンドラを呼び、`sendToAgent()` が `child_process.exec` 経由で本物の `maidctl notify` を子プロセス実行し、全エージェントへ実通知(`Message to X`)がブロードキャストされる事故が発生していた
- **原因**: `maidctl` の `find_project_root()` が `~/.maid-current-project`（session-start-hookが保存）を最優先で読むため、テストが `project=<tmpdir>` で隔離したつもりでも `cwd` に関係なく実プロジェクトへ解決され実配信される
- `child_process.exec` を `util.promisify.custom` を実装したスタブに差し替え、実プロセスを一切起動しないよう修正（`live-service-isolated-testing` スキルの原則）
- `jest.config.js` に `testPathIgnorePatterns: ["/dist/"]` を追加（`dist/__tests__` 二重実行の多重防御。本調査では `testMatch` が拡張子(`.test.ts`)で既に除外する構成のため実害は再現できなかったが、防御的に追加）

## 調査結果（原因の裏取り）
- `--listTests` で確認した限り、本パッケージの `npm test` は `dist/__tests__` を実際には拾っておらず（`testMatch: "**/__tests__/**/*.test.ts"` が拡張子で除外）、「dist二重実行」は本調査では再現できなかった。ただし多重防御として除外設定は追加した
- 「複数のターゲットに送信できる」がタイムアウトしていたのも、10ターゲット分の実プロセス起動(tmux send-keys等)が5000ms内に終わらなかったことが原因と判明。モック化により15秒→数百msに短縮
- 「有効なリクエストでhistory.logに追記される」がENOENTで失敗していたのも、成功時のproduction codeはローカルhistory.logに書き込まない仕様（`sendToAgent`はexec成功時に`true`を返すのみ）ため、実は「本物のexecが成功して実配信された」ことに依存した壊れたテストだったと判明。今回、成功パスは実行コマンドの検証に、フォールバック(exec失敗時)のhistory.log書き込みは新規テストで別途検証する形に整理した

## 実機確認
MaidsHouse本番の `.maid-agent/system/data/notifications/history.log` を本PRのテスト実行前後で確認し、新規エントリが増えていないことを確認済み。

## 提案（実装は判断待ち・本PRのスコープ外）
`maidctl` の `find_project_root()` に環境変数オーバーライド（`~/.maid-current-project` より優先する仕組み）を追加する恒久案は、影響範囲（全maidctlコマンドの解決ロジックに関わる）が大きいため、本PRでは実装せず提案に留める。ご主人様/チームでの検討を推奨。

## 背景調査（git log裏取り）
- `~/.maid-current-project`（session-start-hookによるプロジェクトルート自動検出）は本リポジトリの `3ba1480`（2026-03-05, "feat(maidctl): プロジェクトルート自動検出"）で導入済み。この機構自体は今回の事故の3ヶ月以上前から存在する
- MaidsHouse側のwatchdogレートリミット検出改善（task-1447系）は2026-07-03と非常に最近（本事故報告の5日前）。MaidsHouseは非git管理のためこちらのgit log裏取りはできなかったが、tasks.yamlのcreatedAtで時期のみ確認。以前はセッション断・maidctl呼び出し失敗が相対的に多く、結果的に隔離が「偶然」成立していた可能性はあるが、これは状況証拠であり確定的な因果関係の証明はできていない

## Test plan
- [x] notification-api-routes.test.ts: 全15件パス（exec呼び出し引数の検証・フォールバック書き込みの新規テストを含む）
- [x] `npm run build`(`tsc --noEmit`) 通過
- [x] `packages/maid-agent-messenger` 全jestテスト: 41スイート/505テスト全パス
- [x] 実機確認: 本番history.logに新規エントリが増えないことを確認（規律3）

🤖 Generated with [Claude Code](https://claude.com/claude-code)