### PR TITLE
fix(task-1512-1): maid-worktree-add の名義誤判定(butler)を修正

### DIFF
--- a/global-templates/bin/maid-worktree-add
+++ b/global-templates/bin/maid-worktree-add
@@ -14,18 +14,45 @@
 #
 # エージェント名解決順序:
 #   1. --maid-id オプション
-#   2. MAID_AGENT_ID 環境変数
-#   3. tmux ウィンドウ名（tmux 環境時のみ）
+#   2. CODELODIS_AGENT_ID 環境変数（メイド起動時にwatchdog.sh/エージェント起動処理が
+#      実際にexportする変数。旧実装はMAID_AGENT_IDのみを見ており、この変数名の
+#      不一致により常にこの段が失敗しフォールバック(3)に落ちていた。task-1512-1で修正）
+#   2b. MAID_AGENT_ID 環境変数（互換性のため引き続き参照）
+#   3. tmux ウィンドウ名（tmux環境時のみ。★自分のペイン(-t "$TMUX_PANE")を明示指定する。
+#      指定しないと tmux display-message は「クライアントが現在アクティブに見ている
+#      ウィンドウ名」を返すため、他エージェント（butler等）のウィンドウがアクティブな
+#      タイミングで実行すると誤ったIDを取得する。task-1512-1のflora誤判定事故の
+#      直接的な根本原因。実機で再現・修正確認済み）
 #   4. git config --global maid.defaultAgent
-#   ※ 全て未設定時は警告のみ（git worktree add はブロックしない）
+#
+# フェイルセーフ（task-1512-1で追加）:
+#   - 名義が最後まで解決できない場合、または解決結果が butler/chief/bash 等の
+#     予約済み非メイド識別子と一致した場合は、worktreeを作成する前にエラー停止する
+#     （誤った名義・未設定名義のまま worktree だけ作られる状態を作らない）
 #
 # メールアドレス形式: <maid_id>@maid-agent.local
 # =============================================================================
 
 set -euo pipefail
 
+# 誤判定・誤用が既知のリスクとして確認されている非メイド識別子
+# （tmuxウィンドウ名フォールバックが誤って拾いうる司令塔側の識別子）
+RESERVED_NON_MAID_IDS=(butler chief bash)
+
+is_reserved_id() {
+    local candidate="$1"
+    local reserved
+    for reserved in "${RESERVED_NON_MAID_IDS[@]}"; do
+        if [[ "$candidate" == "$reserved" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 # --maid-id オプションを解析
 maid_id=""
+maid_id_source=""
 git_args=()
 
 while [[ $# -gt 0 ]]; do
@@ -36,6 +63,7 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             maid_id="$2"
+            maid_id_source="--maid-id オプション"
             shift 2
             ;;
         *)
@@ -46,20 +74,58 @@ while [[ $# -gt 0 ]]; do
 done
 
 # エージェント名の解決（--maid-id が未指定の場合）
-if [[ -z "$maid_id" ]]; then
-    # 1. MAID_AGENT_ID 環境変数
-    maid_id="${MAID_AGENT_ID:-}"
+if [[ -z "$maid_id" ]] && [[ -n "${CODELODIS_AGENT_ID:-}" ]]; then
+    maid_id="${CODELODIS_AGENT_ID}"
+    maid_id_source="CODELODIS_AGENT_ID 環境変数"
 fi
 
-if [[ -z "$maid_id" ]] && [[ -n "${TMUX:-}" ]]; then
-    # 2. tmux ウィンドウ名
-    maid_id=$(tmux display-message -p '#{window_name}' 2>/dev/null || true)
+if [[ -z "$maid_id" ]] && [[ -n "${MAID_AGENT_ID:-}" ]]; then
+    maid_id="${MAID_AGENT_ID}"
+    maid_id_source="MAID_AGENT_ID 環境変数"
+fi
+
+if [[ -z "$maid_id" ]] && [[ -n "${TMUX:-}" ]] && [[ -n "${TMUX_PANE:-}" ]]; then
+    # 自分のペインを明示指定する（-t 省略はクライアントのアクティブウィンドウを
+    # 返してしまい誤判定の原因になるため必須。task-1512-1参照）
+    maid_id=$(tmux display-message -p -t "$TMUX_PANE" '#{window_name}' 2>/dev/null || true)
+    if [[ -n "$maid_id" ]]; then
+        maid_id_source="tmux ウィンドウ名（pane=${TMUX_PANE}）"
+    fi
 fi
 
 if [[ -z "$maid_id" ]]; then
-    # 3. git global config
     maid_id=$(git config --global maid.defaultAgent 2>/dev/null || true)
+    if [[ -n "$maid_id" ]]; then
+        maid_id_source="git config --global maid.defaultAgent"
+    fi
 fi
+
+# フェイルセーフ1: 予約済み非メイド識別子への誤判定を検知したらエラー停止
+# （worktree作成前に検知し、誤名義のworktreeが作られる状態を防ぐ）
+if [[ -n "$maid_id" ]] && is_reserved_id "$maid_id"; then
+    echo "" >&2
+    echo "ERROR [maid-worktree-add]: 名義解決の結果が予約済み識別子 '${maid_id}' と一致しました（解決元: ${maid_id_source}）。" >&2
+    echo "   誤判定の可能性が高いため、worktreeを作成せずに処理を停止します。" >&2
+    echo "   --maid-id <あなたのメイドID> を明示指定して再実行してください。" >&2
+    echo "" >&2
+    exit 1
+fi
+
+# フェイルセーフ2: 名義が最後まで解決できない場合もエラー停止
+# （worktreeのコミット名義が共有configを継承し誤帰属する既知の事故パターンを防ぐ。
+#  旧実装は警告のみでworktree作成を継続していたが、本ツールの目的（誤帰属の構造的
+#  防止）と矛盾するため停止に変更した）
+if [[ -z "$maid_id" ]]; then
+    echo "" >&2
+    echo "ERROR [maid-worktree-add]: メイドIDを特定できませんでした。" >&2
+    echo "   worktreeのコミット名義が共有configを継承し誤帰属するリスクがあるため、worktreeを作成せずに処理を停止します。" >&2
+    echo "   --maid-id <あなたのメイドID> を明示指定するか、CODELODIS_AGENT_ID を設定してから再実行してください。" >&2
+    echo "   グローバル既定値: git config --global maid.defaultAgent <maid_id>" >&2
+    echo "" >&2
+    exit 1
+fi
+
+maid_email="${maid_id}@maid-agent.local"
 
 # git worktree add を実行
 git worktree add "${git_args[@]}"
@@ -98,7 +164,7 @@ done
 
 if [[ -z "$worktree_path" ]]; then
     echo "⚠️  [maid-worktree-add]: worktree パスを特定できませんでした。" >&2
-    echo "   手動で設定してください: cd <worktree_path> && git config --worktree user.name <maid_id>" >&2
+    echo "   手動で設定してください: cd <worktree_path> && git config --worktree user.name '${maid_id}' && git config --worktree user.email '${maid_email}'" >&2
     exit 0
 fi
 
@@ -107,20 +173,6 @@ if [[ "$worktree_path" != /* ]]; then
     worktree_path="$(pwd)/${worktree_path}"
 fi
 
-# エージェント名未設定の場合は警告のみ（git worktree add はすでに完了済み）
-if [[ -z "$maid_id" ]]; then
-    echo "" >&2
-    echo "⚠️  [maid-worktree-add]: メイドIDを特定できませんでした。" >&2
-    echo "   worktree のコミット名義が共有 config を継承するため、誤帰属が発生する可能性があります。" >&2
-    echo "   手動設定: cd '${worktree_path}' && git config --worktree user.name <maid_id> && git config --worktree user.email <maid_id>@maid-agent.local" >&2
-    echo "   または: export MAID_AGENT_ID=<maid_id> を設定してから再実行してください。" >&2
-    echo "   グローバル既定値: git config --global maid.defaultAgent <maid_id>" >&2
-    echo "" >&2
-    exit 0
-fi
-
-maid_email="${maid_id}@maid-agent.local"
-
 # extensions.worktreeConfig を有効化（未設定リポジトリで git config --worktree が fatal になる問題を防止）
 if ! (cd "$worktree_path" && git config --get extensions.worktreeConfig &>/dev/null); then
     (cd "$worktree_path" && git config extensions.worktreeConfig true) || true
@@ -128,7 +180,7 @@ fi
 
 # worktree 内で git config --worktree を設定
 if (cd "$worktree_path" && git config --worktree user.name "$maid_id" && git config --worktree user.email "$maid_email"); then
-    echo "[maid-worktree-add]: 名義設定完了 — user.name='${maid_id}' user.email='${maid_email}'"
+    echo "[maid-worktree-add]: 名義設定完了 — user.name='${maid_id}' user.email='${maid_email}'（解決元: ${maid_id_source}）"
 else
     echo "⚠️  [maid-worktree-add]: git config --worktree の設定に失敗しました。" >&2
     echo "   手動設定: cd '${worktree_path}' && git config --worktree user.name '${maid_id}' && git config --worktree user.email '${maid_email}'" >&2

--- a/global-templates/bin/test/maid-worktree-add.test.sh
+++ b/global-templates/bin/test/maid-worktree-add.test.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# maid-worktree-add 名義解決テスト（task-1512-1）
+#
+# 背景: floraがmaid-worktree-add実行時にworktree名義がbutlerに誤判定される事故が
+# 発生した。根本原因は2点:
+#   (1) 実際にexportされる環境変数はCODELODIS_AGENT_IDだが、旧実装は
+#       MAID_AGENT_IDのみを見ていたため常にこの段が失敗しtmuxフォールバックへ落ちていた
+#   (2) tmuxフォールバックが `tmux display-message -p '#{window_name}'` を
+#       ペイン指定なしで呼んでおり、tmuxクライアントの「現在アクティブな
+#       ウィンドウ」名を返してしまう（自分のペインの所属ウィンドウとは限らない）
+#
+# 本テストは一時git repoに対して実際にmaid-worktree-addを実行し、
+# 環境変数の解決順序とフェイルセーフ（予約語検知・未解決時のエラー停止）を検証する。
+# tmuxフォールバック自体（実環境のtmuxセッション状態に依存するため）は対象外とし、
+# 別途実機検証済み（報告書参照）。
+#
+# 実行: bash global-templates/bin/test/maid-worktree-add.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${SCRIPT_DIR}/../maid-worktree-add"
+
+pass=0
+fail=0
+
+SANDBOX="$(mktemp -d)"
+cleanup() {
+  rm -rf "${SANDBOX}"
+}
+trap cleanup EXIT
+
+REPO="${SANDBOX}/repo"
+mkdir -p "${REPO}"
+(
+  cd "${REPO}"
+  git init -q
+  git config user.name "sandbox"
+  git config user.email "sandbox@test.local"
+  echo "init" > README.md
+  git add README.md
+  git commit -q -m "init"
+)
+
+wt_counter=0
+# ★next_wt_pathは呼び出し側で `next_wt_path; wt="$CURRENT_WT"` のようにコマンド置換すると
+#  サブシェルでカウンタが増分され親シェルに反映されない（bashの既知の挙動）。
+#  そのため必ず `next_wt_path` を直接呼びグローバル変数 CURRENT_WT を更新する形にする。
+next_wt_path() {
+  wt_counter=$((wt_counter + 1))
+  CURRENT_WT="${SANDBOX}/wt${wt_counter}"
+}
+
+echo "=== maid-worktree-add tests ==="
+echo ""
+
+# -----------------------------------------------------------------------
+# 正常系: CODELODIS_AGENT_ID が設定されていれば正しく名義解決される
+# （旧実装はMAID_AGENT_IDしか見ておらず、この変数では解決できなかった）
+# -----------------------------------------------------------------------
+next_wt_path; wt="$CURRENT_WT"
+if (
+  cd "${REPO}"
+  env -u TMUX -u MAID_AGENT_ID CODELODIS_AGENT_ID=rose "${SCRIPT}" -b "test-branch-$(basename "$wt")" "$wt"
+) >/tmp/out.$$ 2>&1; then
+  actual_name="$(cd "$wt" && git config --worktree user.name 2>/dev/null || true)"
+  actual_email="$(cd "$wt" && git config --worktree user.email 2>/dev/null || true)"
+  if [[ "$actual_name" == "rose" ]] && [[ "$actual_email" == "rose@maid-agent.local" ]]; then
+    echo "PASS: CODELODIS_AGENT_ID=rose → worktree名義がrose/rose@maid-agent.localに設定される"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: CODELODIS_AGENT_ID=rose → 名義が期待と一致しない (name=${actual_name} email=${actual_email})"
+    fail=$((fail + 1))
+  fi
+else
+  echo "FAIL: CODELODIS_AGENT_ID=rose → 正常終了するはずが失敗した"
+  cat /tmp/out.$$ | sed 's/^/    /'
+  fail=$((fail + 1))
+fi
+rm -f /tmp/out.$$
+
+# -----------------------------------------------------------------------
+# 正常系: --maid-id 明示指定が最優先される（env変数より優先）
+# -----------------------------------------------------------------------
+next_wt_path; wt="$CURRENT_WT"
+if (
+  cd "${REPO}"
+  env -u TMUX CODELODIS_AGENT_ID=rose "${SCRIPT}" --maid-id lily -b "test-branch-$(basename "$wt")" "$wt"
+) >/tmp/out.$$ 2>&1; then
+  actual_name="$(cd "$wt" && git config --worktree user.name 2>/dev/null || true)"
+  if [[ "$actual_name" == "lily" ]]; then
+    echo "PASS: --maid-id lily が CODELODIS_AGENT_ID=rose より優先される"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: --maid-id の優先度が期待と異なる (name=${actual_name})"
+    fail=$((fail + 1))
+  fi
+else
+  echo "FAIL: --maid-id lily → 正常終了するはずが失敗した"
+  cat /tmp/out.$$ | sed 's/^/    /'
+  fail=$((fail + 1))
+fi
+rm -f /tmp/out.$$
+
+# -----------------------------------------------------------------------
+# 異常系（フェイルセーフ1）: 予約済み識別子(butler)が解決された場合はエラー停止し、
+# worktreeを作成しない
+# -----------------------------------------------------------------------
+next_wt_path; wt="$CURRENT_WT"
+exit_code=0
+(
+  cd "${REPO}"
+  env -u TMUX -u MAID_AGENT_ID -u CODELODIS_AGENT_ID "${SCRIPT}" --maid-id butler -b "test-branch-$(basename "$wt")" "$wt"
+) >/tmp/out.$$ 2>&1 || exit_code=$?
+if [[ ${exit_code} -eq 1 ]] && ! [[ -d "$wt" ]] && grep -q "予約済み識別子" /tmp/out.$$; then
+  echo "PASS: --maid-id butler → エラー停止(exit 1)・worktree未作成・エラーメッセージあり"
+  pass=$((pass + 1))
+else
+  echo "FAIL: --maid-id butler → 期待した失敗挙動と異なる (exit_code=${exit_code}, wt_exists=$([[ -d "$wt" ]] && echo yes || echo no))"
+  cat /tmp/out.$$ | sed 's/^/    /'
+  fail=$((fail + 1))
+fi
+rm -f /tmp/out.$$
+
+# -----------------------------------------------------------------------
+# 異常系（フェイルセーフ2）: 全ての解決手段が未設定の場合はエラー停止し、
+# worktreeを作成しない
+# -----------------------------------------------------------------------
+next_wt_path; wt="$CURRENT_WT"
+exit_code=0
+(
+  cd "${REPO}"
+  git config --global --unset maid.defaultAgent 2>/dev/null || true
+  env -u TMUX -u MAID_AGENT_ID -u CODELODIS_AGENT_ID "${SCRIPT}" -b "test-branch-$(basename "$wt")" "$wt"
+) >/tmp/out.$$ 2>&1 || exit_code=$?
+if [[ ${exit_code} -eq 1 ]] && ! [[ -d "$wt" ]] && grep -q "メイドIDを特定できませんでした" /tmp/out.$$; then
+  echo "PASS: 全解決手段未設定 → エラー停止(exit 1)・worktree未作成・エラーメッセージあり"
+  pass=$((pass + 1))
+else
+  echo "FAIL: 全解決手段未設定 → 期待した失敗挙動と異なる (exit_code=${exit_code}, wt_exists=$([[ -d "$wt" ]] && echo yes || echo no))"
+  cat /tmp/out.$$ | sed 's/^/    /'
+  fail=$((fail + 1))
+fi
+rm -f /tmp/out.$$
+
+# -----------------------------------------------------------------------
+# 異常系: --maid-id に空文字を渡した場合はエラー（既存挙動の回帰確認）
+# -----------------------------------------------------------------------
+exit_code=0
+(
+  cd "${REPO}"
+  "${SCRIPT}" --maid-id
+) >/tmp/out.$$ 2>&1 || exit_code=$?
+if [[ ${exit_code} -eq 1 ]] && grep -q "メイドIDを指定してください" /tmp/out.$$; then
+  echo "PASS: --maid-id に値なし → エラー停止(exit 1)"
+  pass=$((pass + 1))
+else
+  echo "FAIL: --maid-id に値なし → 期待した失敗挙動と異なる (exit_code=${exit_code})"
+  cat /tmp/out.$$ | sed 's/^/    /'
+  fail=$((fail + 1))
+fi
+rm -f /tmp/out.$$
+
+# -----------------------------------------------------------------------
+# worktreeのクリーンアップ（次のテスト実行への影響を避ける）
+# -----------------------------------------------------------------------
+(
+  cd "${REPO}"
+  for i in $(seq 1 "$wt_counter"); do
+    git worktree remove "${SANDBOX}/wt${i}" --force 2>/dev/null || true
+  done
+) >/dev/null 2>&1 || true
+
+echo ""
+echo "Results: ${pass} passed, ${fail} failed"
+[[ ${fail} -eq 0 ]]


### PR DESCRIPTION
## 概要
task-1509系作業中、floraがmaid-worktree-add実行時にworktree名義がbutlerに誤判定される事故が発生（手動修正済み・実害なし）。maid-worktree-addは名義誤帰属防止のためのツールであり、その自己矛盾は再発時にprovenance事故（verification-discipline規律2違反）へ直結するため修正した。

## 根本原因（実機調査で特定・再現確認済み）

### 原因1: 環境変数名の不一致
旧実装は`MAID_AGENT_ID`環境変数のみを見ていたが、実際に`watchdog.sh`・`MaidAgentController`（`agent-startup.ts`）がexportするのは`CODELODIS_AGENT_ID`。`MAID_AGENT_ID`は実運用で常に未設定だったため、名義解決は常にtmuxフォールバック（原因2）へ落ちていた。

### 原因2: tmuxウィンドウ名取得のペイン未指定
`tmux display-message -p '#{window_name}'`をペイン指定なしで呼んでおり、**tmuxクライアントの「現在アクティブなウィンドウ」名を返してしまう**（呼び出し元自身のペインが属するウィンドウとは限らない）。

実機で butler ウィンドウがアクティブな状態を再現したところ:
```
$ tmux display-message -p '#{window_name}'          # ペイン指定なし（旧実装）
butler
$ tmux display-message -p -t "$TMUX_PANE" '#{window_name}'  # ペイン指定あり（修正版）
alice
```
flora誤判定事故の直接的な再現に成功した。

## 修正内容
- `CODELODIS_AGENT_ID`環境変数を優先チェック（`MAID_AGENT_ID`は互換性のためフォールバックとして継続参照）
- tmuxウィンドウ名取得に`-t "$TMUX_PANE"`を追加
- フェイルセーフ1: 解決結果が予約済み非メイド識別子（butler/chief/bash）と一致した場合、worktree作成前にエラー停止（exit 1）
- フェイルセーフ2: 名義が最後まで解決できない場合も、worktree作成前にエラー停止（exit 1）に変更（旧: 警告のみでworktree作成を継続していたが、誤帰属防止という本ツールの目的と矛盾していたため）

## テスト
`global-templates/bin/test/maid-worktree-add.test.sh`を新規追加（既存のbin/test形式に準拠）。5ケース全通過:
- CODELODIS_AGENT_ID環境変数からの正常な名義解決
- --maid-id明示指定の優先度
- 予約語(butler)フェイルセーフ（worktree未作成・エラー終了を確認）
- 全解決手段未設定時のフェイルセーフ（worktree未作成・エラー終了を確認）
- 既存の引数検証（--maid-id値なし）の回帰確認

## 動作確認
- 実際のtmuxセッション（butlerウィンドウがアクティブな状態）でflora事故の再現条件を再現し、修正版が正しく'alice'を解決することを確認
- サンドボックスgit repo（隔離環境）での動的テストを別途実施
- pre-commitフック（CHMOD/PROVENANCE）通過確認

## 配布
`.maid-agent/system/bin/maid-worktree-add`（MaidsHouse root・git管理外）にも同一の修正を配布予定（本PRのマージ後、または並行して実施）。

## Test plan
- [ ] レビュアーによるコードレビュー
- [ ] （任意）レビュアー自身のtmux環境での再現確認

🤖 Generated with Claude Code