### PR TITLE
fix(task-1513-1): maid-notifyの送信元解決がtmux依存の単一障害点だったのを修正

### DIFF
--- a/project-templates/system/bin/maid-notify
+++ b/project-templates/system/bin/maid-notify
@@ -334,15 +334,32 @@ MESSAGE="$2"
 validate_target "$TARGET" || exit 1
 
 # 送信者を特定
+# 解決順序（task-1513-1で見直し）:
+#   1. --from 明示指定
+#   2. CODELODIS_AGENT_ID 環境変数（Claude Codeプロセス起動時にVSCode拡張がexportする値。
+#      tmuxウィンドウ名より信頼性が高い一次情報。butler/chief/メイドいずれのセッションにも
+#      設定される。tmuxサーバの一時的な不調・pane再生成等でtmux display-messageが失敗した
+#      場合でも影響を受けない）
+#   3. tmux/psmuxウィンドウ名（フォールバック。マルチプレクサ種別に応じたペイン変数を使用）
+#   4. unknown（解決不能時）
 if [ -n "$EXPLICIT_SENDER" ]; then
-    # --from で明示的に指定された場合
     SENDER="$EXPLICIT_SENDER"
-elif [ -n "$TMUX_PANE" ]; then
-    # tmux/psmux内から実行された場合
-    SENDER=$($MUX_CMD display-message -p -t "$TMUX_PANE" '#{window_name}' 2>/dev/null || echo "unknown")
+elif [ -n "${CODELODIS_AGENT_ID:-}" ]; then
+    SENDER="$CODELODIS_AGENT_ID"
 else
-    # それ以外は unknown
-    SENDER="unknown"
+    # マルチプレクサ種別に応じたペイン変数を選択（$MUX_CMDと不整合だとpsmux環境で
+    # 常にunknown化するため、get_agent_id_from_multiplexer と同じ分岐を踏襲する）
+    case "$MUX_CMD" in
+        psmux) mux_pane_var="${PSMUX_PANE:-}" ;;
+        tmux)  mux_pane_var="${TMUX_PANE:-}" ;;
+        *)     mux_pane_var="" ;;
+    esac
+
+    if [ -n "$mux_pane_var" ]; then
+        SENDER=$($MUX_CMD display-message -p -t "$mux_pane_var" '#{window_name}' 2>/dev/null || echo "unknown")
+    else
+        SENDER="unknown"
+    fi
 fi
 
 # タイムスタンプを取得

--- a/project-templates/system/bin/test/maid-notify.test.sh
+++ b/project-templates/system/bin/test/maid-notify.test.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# maid-notify 送信元(SENDER)解決テスト（task-1513-1）
+#
+# 背景: 執事セッションからのnotifyが「unknown」と記録される事象が発生した。
+# 旧実装はSENDER解決をtmux/psmuxウィンドウ名の取得のみに依存しており、tmuxサーバの
+# 一時的な不調・pane再生成等でdisplay-messageが失敗すると即unknownに落ちていた。
+# 一方、Claude Codeプロセス起動時にVSCode拡張がexportするCODELODIS_AGENT_ID
+# （butler/chief/メイド問わず設定される）という、tmux状態に依存しない、より信頼性の
+# 高い情報源が既に存在するのに未使用だった。
+#
+# 本テストは実際にmaid-notifyスクリプト全体をサンドボックス環境で実行し、
+# ログに記録されるSENDER値を検証する（tmux/psmuxはモックコマンドで制御）。
+# target（送信先）は常にオフライン状態にして送信処理自体はpendingで止め、
+# SENDER解決ロジックのみを対象にする。
+#
+# 実行: bash project-templates/system/bin/test/maid-notify.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${SCRIPT_DIR}/../maid-notify"
+
+pass=0
+fail=0
+
+SANDBOX="$(mktemp -d)"
+cleanup() {
+  rm -rf "${SANDBOX}"
+}
+trap cleanup EXIT
+
+# --- サンドボックスの .maid-agent 構造を最小構築 ---
+setup_sandbox() {
+  rm -rf "${SANDBOX}/proj"
+  mkdir -p "${SANDBOX}/proj/.maid-agent/system/config"
+  mkdir -p "${SANDBOX}/proj/.maid-agent/system/data/notifications"
+  echo "test-session" > "${SANDBOX}/proj/.maid-agent/system/config/.session-name"
+}
+
+# --- モックtmux/psmuxをPATH先頭に配置 ---
+# $1=ツール名(tmux|psmux) $2=display-message実行時に返す値（空なら失敗させる）
+setup_mock_mux() {
+  local tool="$1" ret_value="$2"
+  mkdir -p "${SANDBOX}/mockbin"
+  cat > "${SANDBOX}/mockbin/${tool}" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "display-message" ]]; then
+  if [[ -n "${ret_value}" ]]; then
+    echo "${ret_value}"
+    exit 0
+  else
+    exit 1
+  fi
+fi
+if [[ "\$1" == "list-windows" ]]; then
+  # check_target_online が常にオフライン判定になるよう空を返す
+  exit 0
+fi
+if [[ "\$1" == "send-keys" ]]; then
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "${SANDBOX}/mockbin/${tool}"
+}
+
+run_notify() {
+  # $@ = maid-notifyへの引数。SANDBOX/proj で実行しhistory.logを検証する。
+  (
+    cd "${SANDBOX}/proj"
+    PATH="${SANDBOX}/mockbin:${PATH}" "${SCRIPT}" "$@"
+  ) >/tmp/maid_notify_out.$$ 2>&1
+}
+
+last_sender_in_log() {
+  # history.log には通常行 "[TS] SENDER → TARGET: MSG" の直後に、target がオフラインの
+  # 場合のみ "[TS] [PENDING] SENDER → TARGET (offline): MSG" が追記される（本テストの
+  # targetは常にオフラインのためこのケースに該当）。SENDER自体は両行で同一のため、
+  # 先頭に追加の "[PENDING]" 等の角括弧が付かない「通常行」の方だけを対象に抽出する。
+  grep -E '^\[[^]]+\] [^[]' "${SANDBOX}/proj/.maid-agent/system/data/notifications/history.log" 2>/dev/null \
+    | tail -1 \
+    | sed -E 's/^\[[^]]+\] ([^ ]+) → .*/\1/'
+}
+
+echo "=== maid-notify SENDER resolution tests ==="
+echo ""
+
+# -----------------------------------------------------------------------
+# 正常系1: CODELODIS_AGENT_ID=butler が設定済みの場合、tmux呼び出しに関わらず
+# butlerが優先される（tmuxは正常応答するモックだが別名を返す設定にして優先度を確認）
+# -----------------------------------------------------------------------
+setup_sandbox
+setup_mock_mux tmux "some-other-window-name"
+if (
+  cd "${SANDBOX}/proj"
+  PATH="${SANDBOX}/mockbin:${PATH}" TMUX=1 TMUX_PANE=%1 CODELODIS_AGENT_ID=butler "${SCRIPT}" chief "test message"
+) >/tmp/out.$$ 2>&1; then :; fi
+actual="$(last_sender_in_log)"
+if [[ "$actual" == "butler" ]]; then
+  echo "PASS: CODELODIS_AGENT_ID=butler が tmuxウィンドウ名より優先される"
+  pass=$((pass + 1))
+else
+  echo "FAIL: CODELODIS_AGENT_ID優先のはずが SENDER=${actual}"
+  cat /tmp/out.$$ | sed 's/^/    /'
+  fail=$((fail + 1))
+fi
+rm -f /tmp/out.$$
+
+# -----------------------------------------------------------------------
+# 正常系2: CODELODIS_AGENT_ID未設定・tmux正常応答時はtmuxウィンドウ名で解決される
+# （旧実装からの回帰確認）
+# -----------------------------------------------------------------------
+setup_sandbox
+setup_mock_mux tmux "flora"
+if (
+  cd "${SANDBOX}/proj"
+  PATH="${SANDBOX}/mockbin:${PATH}" env -u CODELODIS_AGENT_ID TMUX=1 TMUX_PANE=%9 "${SCRIPT}" chief "test message"
+) >/tmp/out.$$ 2>&1; then :; fi
+actual="$(last_sender_in_log)"
+if [[ "$actual" == "flora" ]]; then
+  echo "PASS: CODELODIS_AGENT_ID未設定時はtmuxウィンドウ名(flora)で解決される"
+  pass=$((pass + 1))
+else
+  echo "FAIL: tmuxフォールバックのはずが SENDER=${actual}"
+  cat /tmp/out.$$ | sed 's/^/    /'
+  fail=$((fail + 1))
+fi
+rm -f /tmp/out.$$
+
+# -----------------------------------------------------------------------
+# 異常系（本事故の再現）: CODELODIS_AGENT_ID未設定・tmux display-messageが
+# 失敗する場合、旧実装ならunknown確定だったケース。CODELODIS_AGENT_IDが
+# 設定されていれば新実装ではunknown化しないことを確認する別ケースと対比するため、
+# ここではCODELODIS_AGENT_ID未設定のままtmux失敗時に正しく"unknown"へ
+# フォールバックすることを確認する（フォールバック自体は維持されるべき）
+# -----------------------------------------------------------------------
+setup_sandbox
+setup_mock_mux tmux ""
+if (
+  cd "${SANDBOX}/proj"
+  PATH="${SANDBOX}/mockbin:${PATH}" env -u CODELODIS_AGENT_ID TMUX=1 TMUX_PANE=%1 "${SCRIPT}" chief "test message"
+) >/tmp/out.$$ 2>&1; then :; fi
+actual="$(last_sender_in_log)"
+if [[ "$actual" == "unknown" ]]; then
+  echo "PASS: CODELODIS_AGENT_ID未設定・tmux失敗時はunknownへフォールバック（既存事故の直接原因パターンを再現・修正後も安全側フォールバックは維持）"
+  pass=$((pass + 1))
+else
+  echo "FAIL: unknownフォールバックのはずが SENDER=${actual}"
+  cat /tmp/out.$$ | sed 's/^/    /'
+  fail=$((fail + 1))
+fi
+rm -f /tmp/out.$$
+
+# -----------------------------------------------------------------------
+# 本事故の直接修正確認: CODELODIS_AGENT_ID=butler設定済み・tmux display-messageが
+# 失敗するケース（実際の事故で疑われる状況）でも、butlerとして正しく解決される
+# -----------------------------------------------------------------------
+setup_sandbox
+setup_mock_mux tmux ""
+if (
+  cd "${SANDBOX}/proj"
+  PATH="${SANDBOX}/mockbin:${PATH}" TMUX=1 TMUX_PANE=%1 CODELODIS_AGENT_ID=butler "${SCRIPT}" chief "test message"
+) >/tmp/out.$$ 2>&1; then :; fi
+actual="$(last_sender_in_log)"
+if [[ "$actual" == "butler" ]]; then
+  echo "PASS: ★本事故の直接修正確認: tmux display-message失敗時でもCODELODIS_AGENT_ID=butlerによりunknown化しない"
+  pass=$((pass + 1))
+else
+  echo "FAIL: butlerとして解決されるべきが SENDER=${actual}"
+  cat /tmp/out.$$ | sed 's/^/    /'
+  fail=$((fail + 1))
+fi
+rm -f /tmp/out.$$
+
+# -----------------------------------------------------------------------
+# 正常系3: --from 明示指定は最優先される（CODELODIS_AGENT_IDより優先・既存挙動の回帰確認）
+# -----------------------------------------------------------------------
+setup_sandbox
+setup_mock_mux tmux "flora"
+if (
+  cd "${SANDBOX}/proj"
+  PATH="${SANDBOX}/mockbin:${PATH}" TMUX=1 TMUX_PANE=%1 CODELODIS_AGENT_ID=butler "${SCRIPT}" --from master chief "test message"
+) >/tmp/out.$$ 2>&1; then :; fi
+actual="$(last_sender_in_log)"
+if [[ "$actual" == "master" ]]; then
+  echo "PASS: --from master が CODELODIS_AGENT_ID=butler より優先される"
+  pass=$((pass + 1))
+else
+  echo "FAIL: --from優先のはずが SENDER=${actual}"
+  cat /tmp/out.$$ | sed 's/^/    /'
+  fail=$((fail + 1))
+fi
+rm -f /tmp/out.$$
+
+# -----------------------------------------------------------------------
+# 正常系4: psmux環境ではPSMUX_PANEを使って解決される（TMUX_PANEとの不整合修正確認）
+# -----------------------------------------------------------------------
+setup_sandbox
+setup_mock_mux psmux "rose"
+if (
+  cd "${SANDBOX}/proj"
+  PATH="${SANDBOX}/mockbin:${PATH}" env -u TMUX -u CODELODIS_AGENT_ID MAID_MULTIPLEXER=psmux PSMUX_PANE=pane1 "${SCRIPT}" chief "test message"
+) >/tmp/out.$$ 2>&1; then :; fi
+actual="$(last_sender_in_log)"
+if [[ "$actual" == "rose" ]]; then
+  echo "PASS: psmux環境でPSMUX_PANEを使ってウィンドウ名(rose)が解決される"
+  pass=$((pass + 1))
+else
+  echo "FAIL: psmux解決のはずが SENDER=${actual}"
+  cat /tmp/out.$$ | sed 's/^/    /'
+  fail=$((fail + 1))
+fi
+rm -f /tmp/out.$$
+
+echo ""
+echo "Results: ${pass} passed, ${fail} failed"
+[[ ${fail} -eq 0 ]]


### PR DESCRIPTION
## 概要
執事セッションからの`maidctl notify`の送信元が「unknown」と記録される事象が発生した。task-1512（PR#17）のmaid-worktree-add修正がリグレッション源かを最優先で検証したが、否定された（詳細後述）。真の根本原因は`maid-notify`自体のSENDER解決がtmuxウィンドウ名取得の一本足打法だったこと。

## PR#17リグレッション説の検証結果（否定）
- `git diff 97ef4e9`の変更範囲は`global-templates/bin/maid-worktree-add`とそのテストファイルのみ
- `maid-notify`のSENDER解決コードとの共有コードパスは存在しない（`get_agent_id_from_multiplexer`関数はmaid-worktree-addからは一切呼ばれていない）
- 実際のnotify履歴ログを確認したところ、PR#17着地（09:03-09:04）の**18分後の09:22:29まで正常に"butler"表記**でnotifyできていた。最初の"unknown"は10:00:34（PR#17着地から57分後、最後の正常notifyから38分後）。「着地直後」という時系列前提そのものが実際のログとは一致せず、PR#17リグレッション説は否定される

## 根本原因
`maid-notify`のSENDER解決（`cmd_notify`相当の実処理部分）が`tmux/psmuxウィンドウ名取得`のみに依存しており、tmuxサーバの一時的な不調・pane再生成等で`display-message`が失敗すると即`unknown`へフォールバックしていた。

一方、Claude Codeプロセス起動時にVSCode拡張（`agent-startup.ts`の`buildClaudeCommand`）がexportする`CODELODIS_AGENT_ID`は、butler/chief/メイドいずれのセッションにも設定される、tmux状態に依存しないより信頼性の高い情報源であるにもかかわらず、SENDER解決に一切使われていなかった（`maid-worktree-add`の名義解決には既に採用済みだったのと対照的）。

## 修正内容
1. `CODELODIS_AGENT_ID`環境変数を最優先（`--from`明示指定の次）でチェックし、設定済みならtmuxを介さずそれを採用
2. 副次的に発見した不整合も修正: 旧実装はマルチプレクサ種別（`$MUX_CMD`）に関わらず常に`$TMUX_PANE`を参照しており、psmux環境では`$PSMUX_PANE`を使うべきところが不整合だった（`get_agent_id_from_multiplexer`関数は既に正しく分岐していたが、`cmd_notify`内の別実装はこの分岐を踏襲していなかった）
3. tmux/psmux双方が失敗する場合の`unknown`フォールバック自体は維持（安全側の挙動）

## テスト
`project-templates/system/bin/test/maid-notify.test.sh`を新規追加（6ケース全通過）:
- CODELODIS_AGENT_ID優先
- CODELODIS_AGENT_ID未設定時のtmuxフォールバック（既存挙動の回帰確認）
- CODELODIS_AGENT_ID未設定・tmux失敗時のunknownフォールバック維持確認
- ★本事故の直接再現パターン: tmux失敗+CODELODIS_AGENT_ID設定済みで**unknown化しない**ことを確認
- `--from`明示指定の最優先確認
- psmux環境でのPSMUX_PANE分岐修正確認

## 配布
`.maid-agent/system/bin/maid-notify`（MaidsHouse root・git管理外）にも同一の修正を配布予定。

## Test plan
- [ ] レビュアーによるコードレビュー（★自己修正のため第三者レビュー必須）
- [ ] （任意）レビュアー自身の環境での再現確認

🤖 Generated with Claude Code