### PR TITLE
feat(task-1637-9): checkpoint pass に任意--options引数を追加(W-CP)

### DIFF
--- a/global-templates/bin/maidctl
+++ b/global-templates/bin/maidctl
@@ -1379,12 +1379,14 @@ cmd_checkpoint_pass() {
   local agent_id=""
   local summary=""
   local task_id=""
+  local options=""
   local json_output=false
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --summary|-m) summary="$2"; shift 2 ;;
       --task) task_id="$2"; shift 2 ;;
+      --options) options="$2"; shift 2 ;;
       --json) json_output=true; shift ;;
       --help|-h)
         echo "使用法: maidctl checkpoint pass --summary TEXT [オプション]"
@@ -1396,6 +1398,7 @@ cmd_checkpoint_pass() {
         echo "オプション:"
         echo "  --summary, -m TEXT  暫定判断の内容と根拠（必須）"
         echo "  --task ID           対象タスクID（省略時は現在の my-task）"
+        echo "  --options TEXT      検討した選択肢をカンマ区切りで記録（任意。例: \"A案,B案\"）"
         echo "  --json              JSON出力"
         return 0
         ;;
@@ -1439,9 +1442,17 @@ cmd_checkpoint_pass() {
   local task_id_num
   task_id_num=$(echo "$task_id" | sed 's/^task-//')
 
+  # --options はカンマ区切り文字列をJSON配列に変換する（各要素の前後空白はトリム）。
+  # 省略時（空文字）は checkpointPassAdd に options キー自体を含めない（後方互換）。
   local data
-  data=$(jq -n --arg s "$summary" --arg a "$agent_id" \
-    '{checkpointPassAdd: {summary: $s, agentId: $a}}')
+  data=$(jq -n --arg s "$summary" --arg a "$agent_id" --arg o "$options" \
+    '{checkpointPassAdd: ({summary: $s, agentId: $a} + (
+      if $o != "" then
+        {options: ($o | split(",") | map(gsub("^\\s+|\\s+$"; "")))}
+      else
+        {}
+      end
+    ))}')
 
   local result
   result=$(api_request PATCH "/api/tasks/${task_id_num}" "$data")

--- a/global-templates/bin/test/maidctl-checkpoint-pass.test.sh
+++ b/global-templates/bin/test/maidctl-checkpoint-pass.test.sh
@@ -163,6 +163,41 @@ STUB_AGENT_ID="alice"
 rm -f "${REPORT_DIR}/current_alice.md"
 assert_exit_invalid_args "--task 省略・報告書なし → エラー終了(EXIT_INVALID_ARGS)" --summary "報告書なしケース"
 
+# -----------------------------------------------------------------------
+# 正常系（task-1637-9 W-CP）: --options 指定時、カンマ区切りをJSON配列に変換してPATCH
+# -----------------------------------------------------------------------
+STUB_AGENT_ID="rose"
+write_report rose "task-1454-1"
+rm -f "${SANDBOX}/api_calls.log"
+assert_exit_ok "--options 指定 → 正常終了" --summary "暫定判断: A案を採用" --options "A案,B案"
+
+if grep -q '"options"' "${SANDBOX}/api_calls.log" 2>/dev/null \
+  && grep -q '"A案"' "${SANDBOX}/api_calls.log" 2>/dev/null \
+  && grep -q '"B案"' "${SANDBOX}/api_calls.log" 2>/dev/null; then
+  echo "PASS: --options がカンマ区切りからJSON配列に変換されPATCH bodyに含まれる"
+  pass=$((pass + 1))
+else
+  echo "FAIL: --options がPATCH bodyのoptions配列に正しく反映されていない"
+  cat "${SANDBOX}/api_calls.log" 2>/dev/null | sed 's/^/    /'
+  fail=$((fail + 1))
+fi
+
+# -----------------------------------------------------------------------
+# 正常系（task-1637-9 W-CP）: --options 省略時はPATCH bodyにoptionsキーを含めない
+# -----------------------------------------------------------------------
+STUB_AGENT_ID="rose"
+write_report rose "task-1454-1"
+rm -f "${SANDBOX}/api_calls.log"
+run_cmd --summary "options省略ケース" >/dev/null 2>&1
+if grep -q '"options"' "${SANDBOX}/api_calls.log" 2>/dev/null; then
+  echo "FAIL: --options 省略時にもPATCH bodyへoptionsキーが混入している"
+  cat "${SANDBOX}/api_calls.log" 2>/dev/null | sed 's/^/    /'
+  fail=$((fail + 1))
+else
+  echo "PASS: --options 省略時はPATCH bodyにoptionsキーを含めない（後方互換）"
+  pass=$((pass + 1))
+fi
+
 echo ""
 echo "Results: ${pass} passed, ${fail} failed"
 [[ ${fail} -eq 0 ]]

--- a/global-templates/maid-agent-messenger/dist/services/task-crud-update.js
+++ b/global-templates/maid-agent-messenger/dist/services/task-crud-update.js
@@ -235,6 +235,10 @@ export async function executeUpdateTask(projectPath, params) {
                 timestamp: now,
                 summary: params.checkpointPassAdd.summary,
                 agentId: params.checkpointPassAdd.agentId,
+                // task-1637-9 (W-CP): options 省略時はキー自体を含めない（後方互換維持）
+                ...(params.checkpointPassAdd.options !== undefined
+                    ? { options: params.checkpointPassAdd.options }
+                    : {}),
             });
         }
         // 最終更新日時を自動設定

--- a/packages/maid-agent-messenger/src/__tests__/services/task-crud-update-checkpoint-pass.test.ts
+++ b/packages/maid-agent-messenger/src/__tests__/services/task-crud-update-checkpoint-pass.test.ts
@@ -120,6 +120,38 @@ describe("executeUpdateTask - checkpointPassAdd（C-1）", () => {
     ]);
   });
 
+  // task-1637-9 (W-CP): 検討選択肢の記録（変更モーダルでのボタン化に利用予定・W-B1）
+  it("options を指定すると checkpointPassed エントリに options 配列が含まれる", async () => {
+    const result = await executeUpdateTask(PROJECT_PATH, {
+      taskId: "task-1454-1",
+      checkpointPassAdd: {
+        summary: "暫定判断: A案を採用",
+        agentId: "rose",
+        options: ["A案", "B案"],
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.task?.checkpointPassed).toEqual([
+      {
+        timestamp: "2026-07-04T13:00:00+09:00",
+        summary: "暫定判断: A案を採用",
+        agentId: "rose",
+        options: ["A案", "B案"],
+      },
+    ]);
+  });
+
+  it("options を指定しない場合はエントリに options キーを含めない（後方互換）", async () => {
+    const result = await executeUpdateTask(PROJECT_PATH, {
+      taskId: "task-1454-1",
+      checkpointPassAdd: { summary: "暫定判断: dev直接で続行", agentId: "rose" },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.task?.checkpointPassed?.[0]).not.toHaveProperty("options");
+  });
+
   it("checkpointPassAdd を指定しない通常更新では checkpointPassed を変更しない", async () => {
     mockWithTasksLock.mockImplementation(async (_projectPath: string, operation: any) => {
       const data = createMockTasksData({

--- a/packages/maid-agent-messenger/src/services/task-crud-update.ts
+++ b/packages/maid-agent-messenger/src/services/task-crud-update.ts
@@ -260,6 +260,10 @@ export async function executeUpdateTask(
         timestamp: now,
         summary: params.checkpointPassAdd.summary,
         agentId: params.checkpointPassAdd.agentId,
+        // task-1637-9 (W-CP): options 省略時はキー自体を含めない（後方互換維持）
+        ...(params.checkpointPassAdd.options !== undefined
+          ? { options: params.checkpointPassAdd.options }
+          : {}),
       });
     }
 

--- a/packages/types/src/task.ts
+++ b/packages/types/src/task.ts
@@ -66,6 +66,9 @@ export interface CheckpointPassEntry {
   timestamp: string; // 記録日時
   summary: string; // 暫定判断の内容と根拠
   agentId: string; // 記録したエージェントID
+  // task-1637-9 (W-CP): 検討した選択肢（省略可）。CodeLodis側「判断変更」モーダルで
+  // ボタン化して提示するために使う（W-B1）。省略時はエントリにキー自体を含めない。
+  options?: string[];
 }
 
 export type TaskCategory = "task" | "skill_candidate" | "improvement";
@@ -175,7 +178,7 @@ export interface UpdateTaskParams {
   escalation?: EscalationInfo; // エスカレーション情報（checkpoint時）
 
   // === C-1: Type B（通過型チェックポイント）記録 ===
-  checkpointPassAdd?: { summary: string; agentId: string }; // 通過型チェックポイント記録追加（timestampはサーバー側で付与）
+  checkpointPassAdd?: { summary: string; agentId: string; options?: string[] }; // 通過型チェックポイント記録追加（timestampはサーバー側で付与）
 }
 
 export interface SideEffectResults {


### PR DESCRIPTION
## Summary
- `maidctl checkpoint pass` に任意の `--options "A案,B案"` 引数を追加（計画書 §5-4/§6 W-CP）
- `CheckpointPassEntry.options?: string[]` を追加し、省略時はエントリにキー自体を含めない後方互換設計
- CodeLodis側の `checkpoint-review/CheckpointReviewIngestor.ts`（tasks.yamlの一方向コンシューマ）は対象外。ボタン化UIはW-B1が担当

## 変更ファイル
- `packages/types/src/task.ts`
- `packages/maid-agent-messenger/src/services/task-crud-update.ts`
- `packages/maid-agent-messenger/src/__tests__/services/task-crud-update-checkpoint-pass.test.ts`
- `global-templates/bin/maidctl`
- `global-templates/bin/test/maidctl-checkpoint-pass.test.sh`
- `global-templates/maid-agent-messenger/dist/services/task-crud-update.js`（build同期分のみ）

## Test plan
- [x] `task-crud-update-checkpoint-pass.test.ts` 5/5 PASS（TDD: RED確認後に実装）
- [x] `maidctl-checkpoint-pass.test.sh` 8/8 PASS（TDD: RED確認後に実装）
- [x] `maid-agent-messenger` full suite: 41 suites / 510 tests 全PASS（既存機能への回帰なし）

## 補足
- worktreeで `npm run build` 実行時、本タスクと無関係な既存dist drift（task-807, task-1495-1由来。他タスクでのpostbuild同期漏れ）を検知したため、`task-crud-update.js` 以外のdist差分および `package-lock.json` のversion差分は本PRから除外済み。別途chiefへ報告予定。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>