### PR TITLE
feat(vscode): tmuxウィンドウ監視をcontrol modeイベント駆動へ移行（カーネルメモリリーク対策）

### DIFF
--- a/packages/vscode/src/events/__tests__/control-mode-client.test.ts
+++ b/packages/vscode/src/events/__tests__/control-mode-client.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// child_process をモック（spawn のみ使用）
+vi.mock('child_process', () => ({
+    spawn: vi.fn(),
+}));
+
+import { spawn } from 'child_process';
+import {
+    ControlModeParser,
+    ControlModeClient,
+    CONTROL_MODE_RETRY_BASE_MS,
+    CONTROL_MODE_MAX_RETRIES,
+    type ControlModeEvent,
+} from '../control-mode-client';
+
+/**
+ * 疑似 tmux -C プロセス
+ */
+class FakeProcess extends EventEmitter {
+    public stdout = new EventEmitter();
+    public stderr = new EventEmitter();
+    public stdin = { write: vi.fn() };
+    public kill = vi.fn();
+}
+
+function createClient(overrides: Partial<ConstructorParameters<typeof ControlModeClient>[0]> = {}) {
+    const onWindowName = vi.fn();
+    const onFatal = vi.fn();
+    const client = new ControlModeClient({
+        command: 'wsl',
+        args: ['tmux', '-C', 'attach-session', '-t', 'maid-session'],
+        sessionName: 'maid-session',
+        onWindowName,
+        onFatal,
+        ...overrides,
+    });
+    return { client, onWindowName, onFatal };
+}
+
+describe('ControlModeParser', () => {
+    let parser: ControlModeParser;
+
+    beforeEach(() => {
+        parser = new ControlModeParser();
+    });
+
+    it('%begin/%end ブロックの内容を command-output として返すこと', () => {
+        expect(parser.feed('%begin 1721793600 1 0')).toBeNull();
+        expect(parser.feed('flora')).toBeNull();
+        const event = parser.feed('%end 1721793600 1 0');
+        expect(event).toEqual({ type: 'command-output', text: 'flora' });
+    });
+
+    it('複数行のブロック出力を改行結合で返すこと', () => {
+        parser.feed('%begin 1 2 0');
+        parser.feed('line1');
+        parser.feed('line2');
+        const event = parser.feed('%end 1 2 0');
+        expect(event).toEqual({ type: 'command-output', text: 'line1\nline2' });
+    });
+
+    it('%error ブロックを error-output として返すこと', () => {
+        parser.feed('%begin 1 3 0');
+        parser.feed("can't find session");
+        const event = parser.feed('%error 1 3 0');
+        expect(event).toEqual({ type: 'error-output', text: "can't find session" });
+    });
+
+    it('%session-window-changed 通知を window-changed として返すこと', () => {
+        const event = parser.feed('%session-window-changed $2 @15');
+        expect(event).toEqual({ type: 'window-changed' });
+    });
+
+    it('%window-renamed 通知を window-changed として返すこと', () => {
+        const event = parser.feed('%window-renamed @5 emma');
+        expect(event).toEqual({ type: 'window-changed' });
+    });
+
+    it('%exit を exit として返すこと', () => {
+        expect(parser.feed('%exit')).toEqual({ type: 'exit' });
+        expect(parser.feed('%exit detached')).toEqual({ type: 'exit' });
+    });
+
+    it('ブロック外の非通知行は無視すること', () => {
+        expect(parser.feed('random output')).toBeNull();
+        expect(parser.feed('%unknown-notification foo')).toBeNull();
+    });
+});
+
+describe('ControlModeClient', () => {
+    let fakeProc: FakeProcess;
+    const spawnMock = vi.mocked(spawn);
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        fakeProc = new FakeProcess();
+        spawnMock.mockReset();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        spawnMock.mockImplementation(() => fakeProc as any);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('start() で指定コマンドを spawn すること', () => {
+        const { client } = createClient();
+        client.start();
+        expect(spawnMock).toHaveBeenCalledWith(
+            'wsl',
+            ['tmux', '-C', 'attach-session', '-t', 'maid-session'],
+            expect.anything()
+        );
+        client.dispose();
+    });
+
+    it('起動直後に現在ウィンドウ名の初期照会を stdin へ送ること', () => {
+        const { client } = createClient();
+        client.start();
+        expect(fakeProc.stdin.write).toHaveBeenCalledTimes(1);
+        const written = fakeProc.stdin.write.mock.calls[0][0] as string;
+        expect(written).toContain('display-message');
+        expect(written).toContain('maid-session');
+        expect(written).toContain('#{window_name}');
+        client.dispose();
+    });
+
+    it('ウィンドウ変更通知を受けたら再照会を stdin へ送ること', () => {
+        const { client } = createClient();
+        client.start();
+        fakeProc.stdin.write.mockClear();
+        fakeProc.stdout.emit('data', Buffer.from('%session-window-changed $2 @15\n'));
+        expect(fakeProc.stdin.write).toHaveBeenCalledTimes(1);
+        client.dispose();
+    });
+
+    it('ブロック応答からウィンドウ名を onWindowName へ通知すること', () => {
+        const { client, onWindowName } = createClient();
+        client.start();
+        fakeProc.stdout.emit('data', Buffer.from('%begin 1 1 0\nemma\n%end 1 1 0\n'));
+        expect(onWindowName).toHaveBeenCalledWith('emma');
+        client.dispose();
+    });
+
+    it('分割されたチャンクでも行を正しく組み立てること', () => {
+        const { client, onWindowName } = createClient();
+        client.start();
+        fakeProc.stdout.emit('data', Buffer.from('%begin 1 1 0\nso'));
+        fakeProc.stdout.emit('data', Buffer.from('phia\n%end 1 1 0\n'));
+        expect(onWindowName).toHaveBeenCalledWith('sophia');
+        client.dispose();
+    });
+
+    it('dispose() でプロセスを kill し再起動しないこと', () => {
+        const { client } = createClient();
+        client.start();
+        client.dispose();
+        expect(fakeProc.kill).toHaveBeenCalled();
+        // dispose 後のプロセス終了では再spawnしない
+        fakeProc.emit('exit', 0);
+        vi.advanceTimersByTime(CONTROL_MODE_RETRY_BASE_MS * 10);
+        expect(spawnMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('プロセスが予期せず終了したらバックオフ後に再接続すること', () => {
+        const { client } = createClient();
+        client.start();
+        expect(spawnMock).toHaveBeenCalledTimes(1);
+
+        const nextProc = new FakeProcess();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        spawnMock.mockImplementation(() => nextProc as any);
+
+        fakeProc.emit('exit', 1);
+        expect(spawnMock).toHaveBeenCalledTimes(1); // 即時再接続ではない
+        vi.advanceTimersByTime(CONTROL_MODE_RETRY_BASE_MS);
+        expect(spawnMock).toHaveBeenCalledTimes(2);
+        client.dispose();
+    });
+
+    it('連続失敗が上限に達したら onFatal を呼び再接続を止めること', () => {
+        const { client, onFatal } = createClient();
+        client.start();
+
+        for (let i = 0; i < CONTROL_MODE_MAX_RETRIES; i++) {
+            const proc = new FakeProcess();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            spawnMock.mockImplementation(() => proc as any);
+            // 直近のプロセスを終了させ、バックオフを全て消化
+            const current = i === 0 ? fakeProc : spawnMock.mock.results[i]?.value;
+            (current as FakeProcess).emit('exit', 1);
+            vi.advanceTimersByTime(CONTROL_MODE_RETRY_BASE_MS * 2 ** (i + 1));
+        }
+
+        expect(onFatal).toHaveBeenCalledTimes(1);
+        client.dispose();
+    });
+
+    it('ウィンドウ名の受信で失敗カウンタがリセットされること', () => {
+        const { client, onFatal } = createClient();
+        client.start();
+
+        // 1回失敗 → 再接続
+        const proc2 = new FakeProcess();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        spawnMock.mockImplementation(() => proc2 as any);
+        fakeProc.emit('exit', 1);
+        vi.advanceTimersByTime(CONTROL_MODE_RETRY_BASE_MS * 2);
+
+        // 成功応答でカウンタリセット
+        proc2.stdout.emit('data', Buffer.from('%begin 1 1 0\nemma\n%end 1 1 0\n'));
+
+        // 再び上限-1回失敗しても onFatal は呼ばれない（リセットされているため）
+        let prev = proc2;
+        for (let i = 0; i < CONTROL_MODE_MAX_RETRIES - 1; i++) {
+            const proc = new FakeProcess();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            spawnMock.mockImplementation(() => proc as any);
+            prev.emit('exit', 1);
+            vi.advanceTimersByTime(CONTROL_MODE_RETRY_BASE_MS * 2 ** (i + 2));
+            prev = proc;
+        }
+        expect(onFatal).not.toHaveBeenCalled();
+        client.dispose();
+    });
+});

--- a/packages/vscode/src/events/control-mode-client.ts
+++ b/packages/vscode/src/events/control-mode-client.ts
@@ -1,0 +1,248 @@
+/**
+ * tmux control mode 常駐クライアント
+ *
+ * `tmux -C attach-session` を1本だけ常駐させ、ウィンドウ変更通知
+ * （%session-window-changed 等）をイベント駆動で受信する。
+ * 従来の500msポーリング（1回ごとに cmd/wsl/conhost プロセスを生成）を置き換え、
+ * Windows側のプロセス生成をゼロにする（カーネルメモリリーク増幅の抑止）。
+ *
+ * 注意: このモジュールは vscode API に依存しない（単体テスト可能に保つ）。
+ */
+
+import { spawn, ChildProcess } from 'child_process';
+
+/** 再接続バックオフの基準値（ms）。失敗回数に応じて指数的に伸びる */
+export const CONTROL_MODE_RETRY_BASE_MS = 1000;
+
+/** 再接続バックオフの上限（ms） */
+export const CONTROL_MODE_RETRY_MAX_MS = 30000;
+
+/** 連続失敗の上限。超えたら onFatal を呼び、呼び出し側はポーリングへフォールバック */
+export const CONTROL_MODE_MAX_RETRIES = 5;
+
+/**
+ * control mode 出力のパース結果
+ */
+export type ControlModeEvent =
+    | { type: 'command-output'; text: string }
+    | { type: 'error-output'; text: string }
+    | { type: 'window-changed' }
+    | { type: 'exit' };
+
+/** 現在ウィンドウの再照会をトリガーする通知（先頭一致） */
+const WINDOW_CHANGE_NOTIFICATIONS = [
+    '%session-window-changed',
+    '%window-renamed',
+    '%session-changed',
+    '%unlinked-window-renamed',
+];
+
+/**
+ * control mode の行単位パーサ
+ *
+ * - `%begin ... %end`（または `%error`）ブロック: コマンド応答
+ * - `%session-window-changed` 等: ウィンドウ変更通知
+ * - `%exit`: サーバ切断
+ */
+export class ControlModeParser {
+    private inBlock = false;
+    private blockLines: string[] = [];
+
+    feed(line: string): ControlModeEvent | null {
+        if (this.inBlock) {
+            if (line.startsWith('%end ') || line === '%end') {
+                const text = this.blockLines.join('\n');
+                this.reset();
+                return { type: 'command-output', text };
+            }
+            if (line.startsWith('%error ') || line === '%error') {
+                const text = this.blockLines.join('\n');
+                this.reset();
+                return { type: 'error-output', text };
+            }
+            this.blockLines.push(line);
+            return null;
+        }
+
+        if (line.startsWith('%begin ') || line === '%begin') {
+            this.inBlock = true;
+            this.blockLines = [];
+            return null;
+        }
+        if (line.startsWith('%exit') ) {
+            return { type: 'exit' };
+        }
+        if (WINDOW_CHANGE_NOTIFICATIONS.some(prefix => line.startsWith(prefix))) {
+            return { type: 'window-changed' };
+        }
+        return null;
+    }
+
+    private reset(): void {
+        this.inBlock = false;
+        this.blockLines = [];
+    }
+}
+
+/**
+ * ControlModeClient のオプション
+ */
+export interface ControlModeClientOptions {
+    /** spawn するコマンド（例: Windows ホストなら 'wsl'、それ以外は 'tmux'） */
+    command: string;
+    /** spawn 引数（例: ['tmux', '-C', 'attach-session', '-t', SESSION]） */
+    args: string[];
+    /** 監視対象セッション名 */
+    sessionName: string;
+    /** 現在ウィンドウ名の受信コールバック */
+    onWindowName: (name: string) => void;
+    /** 連続失敗上限到達時のコールバック（ポーリングへのフォールバック等） */
+    onFatal?: () => void;
+    /** ログ出力（省略可） */
+    onLog?: (msg: string) => void;
+}
+
+/**
+ * tmux control mode 常駐クライアント
+ *
+ * 使い方:
+ *   const client = new ControlModeClient({...});
+ *   client.start();
+ *   ...
+ *   client.dispose();
+ */
+export class ControlModeClient {
+    private readonly options: ControlModeClientOptions;
+    private proc: ChildProcess | undefined;
+    private parser = new ControlModeParser();
+    private lineBuffer = '';
+    private disposed = false;
+    private consecutiveFailures = 0;
+    private retryTimer: NodeJS.Timeout | undefined;
+
+    constructor(options: ControlModeClientOptions) {
+        this.options = options;
+    }
+
+    start(): void {
+        if (this.disposed || this.proc) return;
+        this.spawnProcess();
+    }
+
+    dispose(): void {
+        this.disposed = true;
+        if (this.retryTimer) {
+            clearTimeout(this.retryTimer);
+            this.retryTimer = undefined;
+        }
+        this.killProcess();
+    }
+
+    private spawnProcess(): void {
+        this.parser = new ControlModeParser();
+        this.lineBuffer = '';
+
+        const proc = spawn(this.options.command, this.options.args, {
+            stdio: ['pipe', 'pipe', 'pipe'],
+            windowsHide: true,
+        });
+        this.proc = proc;
+
+        proc.stdout?.on('data', (chunk: Buffer | string) => this.handleData(chunk));
+        proc.on('error', (err: Error) => {
+            this.log(`control mode spawn error: ${err.message}`);
+        });
+        proc.on('exit', () => this.handleExit());
+
+        // 初期状態の取得（接続直後の現在ウィンドウ名）
+        this.queryCurrentWindow();
+    }
+
+    private killProcess(): void {
+        if (this.proc) {
+            try {
+                this.proc.kill();
+            } catch (err) {
+                this.log(`control mode kill failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+            this.proc = undefined;
+        }
+    }
+
+    /**
+     * 現在のアクティブウィンドウ名を同一接続の stdin 経由で照会する
+     * （新規プロセスは生成されない）
+     */
+    private queryCurrentWindow(): void {
+        const cmd = `display-message -t ${this.options.sessionName} -p "#{window_name}"\n`;
+        try {
+            this.proc?.stdin?.write(cmd);
+        } catch (err) {
+            this.log(`control mode stdin write failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+
+    private handleData(chunk: Buffer | string): void {
+        this.lineBuffer += chunk.toString();
+        let newlineIndex = this.lineBuffer.indexOf('\n');
+        while (newlineIndex >= 0) {
+            const line = this.lineBuffer.slice(0, newlineIndex).replace(/\r$/, '');
+            this.lineBuffer = this.lineBuffer.slice(newlineIndex + 1);
+            this.handleLine(line);
+            newlineIndex = this.lineBuffer.indexOf('\n');
+        }
+    }
+
+    private handleLine(line: string): void {
+        const event = this.parser.feed(line);
+        if (!event) return;
+
+        switch (event.type) {
+            case 'window-changed':
+                this.queryCurrentWindow();
+                break;
+            case 'command-output': {
+                const name = event.text.trim();
+                if (name.length > 0) {
+                    this.consecutiveFailures = 0;
+                    this.options.onWindowName(name);
+                }
+                break;
+            }
+            case 'error-output':
+                this.log(`control mode command error: ${event.text}`);
+                break;
+            case 'exit':
+                // この後プロセスの exit イベントで再接続処理される
+                break;
+        }
+    }
+
+    private handleExit(): void {
+        this.proc = undefined;
+        if (this.disposed) return;
+
+        this.consecutiveFailures++;
+        if (this.consecutiveFailures >= CONTROL_MODE_MAX_RETRIES) {
+            this.log(`control mode: 連続${this.consecutiveFailures}回失敗。フォールバックします`);
+            this.options.onFatal?.();
+            return;
+        }
+
+        const delay = Math.min(
+            CONTROL_MODE_RETRY_BASE_MS * 2 ** (this.consecutiveFailures - 1),
+            CONTROL_MODE_RETRY_MAX_MS
+        );
+        this.log(`control mode: 切断検出。${delay}ms 後に再接続します（${this.consecutiveFailures}回目）`);
+        this.retryTimer = setTimeout(() => {
+            this.retryTimer = undefined;
+            if (!this.disposed) {
+                this.spawnProcess();
+            }
+        }, delay);
+    }
+
+    private log(msg: string): void {
+        this.options.onLog?.(`[control-mode] ${msg}`);
+    }
+}

--- a/packages/vscode/src/events/tmux-watcher.ts
+++ b/packages/vscode/src/events/tmux-watcher.ts
@@ -3,12 +3,19 @@
  *
  * tmuxセッション内のアクティブウィンドウを監視し、
  * 現在のエージェントをパネルに反映する。
+ *
+ * 監視方式は2段構え:
+ * 1. control mode 常駐クライアント（イベント駆動・プロセス生成ゼロ）… tmux のみ
+ * 2. 500msポーリング … psmux、または control mode が利用不能な場合のフォールバック
+ *    （ポーリングは1回ごとに cmd/wsl/conhost プロセスを生成するため、
+ *      カーネルメモリリークの増幅要因になる。可能な限り 1. を使う）
  */
 
 import * as vscode from 'vscode';
 import { Agent } from '../types';
 import { ITerminalMultiplexer } from '../multiplexer';
 import { AgentPanelProvider } from '../ui/agent-panel-provider';
+import { ControlModeClient } from './control-mode-client';
 
 /**
  * tmux監視に必要なコンテキスト
@@ -28,6 +35,10 @@ export interface TmuxWatcherContext {
 export interface TmuxWatcherState {
     pollingInterval: NodeJS.Timeout | undefined;
     lastDetectedAgentId: string | null;
+    /** control mode 常駐クライアント（イベント駆動監視） */
+    controlModeClient: ControlModeClient | undefined;
+    /** control mode が失敗しポーリングへ恒久フォールバックしたか */
+    controlModeFailed: boolean;
 }
 
 /**
@@ -37,6 +48,8 @@ export function createTmuxWatcherState(): TmuxWatcherState {
     return {
         pollingInterval: undefined,
         lastDetectedAgentId: null,
+        controlModeClient: undefined,
+        controlModeFailed: false,
     };
 }
 
@@ -95,12 +108,12 @@ export function setCurrentAgentFromTerminal(
 
     if (!agentId && isTmuxViewer) {
         agentId = getCurrentTmuxWindowAgent(ctx);
-        startTmuxWindowPolling(ctx, state);
+        startTmuxWindowWatching(ctx, state);
     } else if (!agentId && terminalName.includes('Maid Agent')) {
         // ターミナル名でtmuxビューアを判定（参照比較の代替）
         ctx.log(`[AgentPanel] tmuxビューア検出（名前ベース）: ${terminalName}`);
         agentId = getCurrentTmuxWindowAgent(ctx);
-        startTmuxWindowPolling(ctx, state);
+        startTmuxWindowWatching(ctx, state);
     } else {
         stopTmuxWindowPolling(ctx, state);
     }
@@ -109,7 +122,67 @@ export function setCurrentAgentFromTerminal(
 }
 
 /**
+ * 検出したウィンドウ名をエージェントIDに解決し、変更時のみパネルへ反映する
+ */
+function handleDetectedWindowName(
+    ctx: TmuxWatcherContext,
+    state: TmuxWatcherState,
+    windowName: string | null
+): void {
+    const currentAgentId = windowName && ctx.agents.has(windowName) ? windowName : null;
+
+    if (currentAgentId !== state.lastDetectedAgentId) {
+        ctx.log(`[AgentPanel] tmuxウィンドウ変更検出: ${state.lastDetectedAgentId} → ${currentAgentId}`);
+        state.lastDetectedAgentId = currentAgentId;
+        if (ctx.agentPanelProvider) {
+            ctx.agentPanelProvider.setCurrentAgent(currentAgentId);
+        }
+    }
+}
+
+/**
+ * tmuxウィンドウの監視を開始
+ *
+ * control mode（イベント駆動）を優先し、非対応または失敗時のみポーリングを使う。
+ */
+export function startTmuxWindowWatching(
+    ctx: TmuxWatcherContext,
+    state: TmuxWatcherState
+): void {
+    if (state.controlModeClient || state.pollingInterval) return; // 既に実行中
+
+    const spawnSpec = !state.controlModeFailed
+        ? ctx.tmuxManager?.getControlModeSpawn() ?? null
+        : null;
+
+    if (!spawnSpec) {
+        startTmuxWindowPolling(ctx, state);
+        return;
+    }
+
+    state.controlModeClient = new ControlModeClient({
+        command: spawnSpec.command,
+        args: spawnSpec.args,
+        sessionName: ctx.tmuxSessionName,
+        onWindowName: (name) => handleDetectedWindowName(ctx, state, name),
+        onLog: (msg) => ctx.log(msg),
+        onFatal: () => {
+            // control mode が使えない環境ではポーリングへフォールバック
+            ctx.log('[tmux] control mode が利用できないためポーリングへフォールバックします');
+            state.controlModeFailed = true;
+            state.controlModeClient = undefined;
+            startTmuxWindowPolling(ctx, state);
+        },
+    });
+    state.controlModeClient.start();
+    ctx.log('[tmux] control mode によるウィンドウ監視を開始（イベント駆動）');
+}
+
+/**
  * tmuxウィンドウのポーリングを開始（500msごとにチェック）
+ *
+ * 注意: 1回ごとに子プロセスを生成するため、control mode が使えない場合の
+ * フォールバック専用。直接呼ばず startTmuxWindowWatching を使うこと。
  */
 export function startTmuxWindowPolling(
     ctx: TmuxWatcherContext,
@@ -119,32 +192,33 @@ export function startTmuxWindowPolling(
 
     state.pollingInterval = setInterval(() => {
         const currentAgentId = getCurrentTmuxWindowAgent(ctx);
-
-        // 変更があった場合のみ更新
-        if (currentAgentId !== state.lastDetectedAgentId) {
-            ctx.log(`[AgentPanel] tmuxウィンドウ変更検出: ${state.lastDetectedAgentId} → ${currentAgentId}`);
-            state.lastDetectedAgentId = currentAgentId;
-            if (ctx.agentPanelProvider) {
-                ctx.agentPanelProvider.setCurrentAgent(currentAgentId);
-            }
-        }
+        handleDetectedWindowName(ctx, state, currentAgentId);
     }, 500);
 
     ctx.log('[tmux] ウィンドウ監視ポーリングを開始');
 }
 
 /**
- * tmuxウィンドウのポーリングを停止
+ * tmuxウィンドウの監視を停止（control mode・ポーリング共通）
  */
 export function stopTmuxWindowPolling(
     ctx: TmuxWatcherContext,
     state: TmuxWatcherState
 ): void {
+    let stopped = false;
+    if (state.controlModeClient) {
+        state.controlModeClient.dispose();
+        state.controlModeClient = undefined;
+        stopped = true;
+    }
     if (state.pollingInterval) {
         clearInterval(state.pollingInterval);
         state.pollingInterval = undefined;
+        stopped = true;
+    }
+    if (stopped) {
         state.lastDetectedAgentId = null;
-        ctx.log('[tmux] ウィンドウ監視ポーリングを停止');
+        ctx.log('[tmux] ウィンドウ監視を停止');
     }
 }
 
@@ -152,6 +226,10 @@ export function stopTmuxWindowPolling(
  * tmux監視の状態をクリーンアップ
  */
 export function disposeTmuxWatcher(state: TmuxWatcherState): void {
+    if (state.controlModeClient) {
+        state.controlModeClient.dispose();
+        state.controlModeClient = undefined;
+    }
     if (state.pollingInterval) {
         clearInterval(state.pollingInterval);
         state.pollingInterval = undefined;

--- a/packages/vscode/src/multiplexer/base-adapter.ts
+++ b/packages/vscode/src/multiplexer/base-adapter.ts
@@ -1,5 +1,5 @@
 import { execSync, exec } from 'child_process';
-import { ITerminalMultiplexer, MultiplexerType } from './interfaces';
+import { ITerminalMultiplexer, MultiplexerType, ControlModeSpawnSpec } from './interfaces';
 import { escapeForDoubleQuote, quoteArg, type ShellType } from '../utils/shell-escape';
 
 // ステータスバー2行表示のフォーマット（tmux用デフォルト）
@@ -242,6 +242,11 @@ export abstract class AbstractMultiplexerAdapter implements ITerminalMultiplexer
         } catch {
             return null;
         }
+    }
+
+    getControlModeSpawn(): ControlModeSpawnSpec | null {
+        // デフォルトは非対応（tmux アダプターのみオーバーライドで対応）
+        return null;
     }
 
     // ========== キー送信 ==========

--- a/packages/vscode/src/multiplexer/interfaces.ts
+++ b/packages/vscode/src/multiplexer/interfaces.ts
@@ -10,6 +10,14 @@
 export type MultiplexerType = 'tmux' | 'psmux';
 
 /**
+ * control mode 常駐クライアント用の spawn 指定
+ */
+export interface ControlModeSpawnSpec {
+    command: string;
+    args: string[];
+}
+
+/**
  * 環境設定
  */
 export interface MultiplexerConfig {
@@ -91,6 +99,12 @@ export interface ITerminalMultiplexer {
      * 現在アクティブなウィンドウ名を取得
      */
     getCurrentWindowName(): string | null;
+
+    /**
+     * control mode 常駐クライアント用の spawn 指定を取得
+     * 非対応のマルチプレクサは null を返す（呼び出し側はポーリングにフォールバック）
+     */
+    getControlModeSpawn(): ControlModeSpawnSpec | null;
 
     // ========== その他 ==========
 

--- a/packages/vscode/src/multiplexer/tmux-adapter.ts
+++ b/packages/vscode/src/multiplexer/tmux-adapter.ts
@@ -1,5 +1,5 @@
 import { AbstractMultiplexerAdapter } from './base-adapter';
-import { MultiplexerType } from './interfaces';
+import { MultiplexerType, ControlModeSpawnSpec } from './interfaces';
 import { windowsToWslPath } from '../utils/environment';
 import type { ShellType } from '../utils/shell-escape';
 
@@ -36,6 +36,13 @@ export class TmuxAdapter extends AbstractMultiplexerAdapter {
     protected getCommandPrefix(): string {
         // Windows環境: wsl経由でtmuxを実行
         return this.isWindowsHost ? 'wsl tmux' : 'tmux';
+    }
+
+    override getControlModeSpawn(): ControlModeSpawnSpec | null {
+        const tmuxArgs = ['-C', 'attach-session', '-t', this.sessionName];
+        return this.isWindowsHost
+            ? { command: 'wsl', args: ['tmux', ...tmuxArgs] }
+            : { command: 'tmux', args: tmuxArgs };
     }
 
     protected getCommandWorkingDirectory(): string {


### PR DESCRIPTION
## 背景

DESKTOP-ISTUC8I の非ページプールリーク調査（2026-07-23〜24）で、tmux-watcher の500msポーリングが1回ごとに cmd/wsl/conhost の Windows プロセスを生成し、カーネル側のゾンビプロセスリーク（Proc/MiP2タグ・全プロセス100%残留）の主要な増幅要因になっていることが判明した。

調査記録: MaidsHouse `docs/research/tmux-watcher-event-driven-investigation-2026-07-24.md`

## 変更内容

- **control-mode-client.ts（新規）**: `tmux -C attach-session` 常駐クライアント。%session-window-changed 等の通知をイベント駆動で受信し、同一接続のstdin経由で `display-message` を照会（プロセス生成ゼロ）。指数バックオフ再接続・連続失敗時 onFatal
- **tmux-watcher.ts**: `startTmuxWindowWatching` 新設。control mode 優先、非対応（psmux）または連続失敗時は従来の500msポーリングへフォールバック
- **multiplexer**: `getControlModeSpawn()` を ITerminalMultiplexer に追加（tmuxアダプターのみ対応・基底は null）

## テスト

- TDD（テスト先行コミット → 実装）
- 新規16テスト全通過（ControlModeParser 7件 / ControlModeClient 9件）
- 既存テスト退行ゼロ（dev ベースラインの既存失敗25件は変更前後で同一・本変更と無関係）
- `npm run compile:tsc` / `npm run compile`（esbuild）通過

## 動作確認の残項目

- Windsurf 実機での拡張動作確認（control mode 接続・ウィンドウ切替追従・プロセス生成が止まったことの pooltags.ps1 計測）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2HGmiUnMfpqXFeF5AaL6D