### PR TITLE
feat(vscode): control mode フォールバックの自己回復と dispose 堅牢化（PR #21 SHOULD対応）

### DIFF
--- a/packages/vscode/src/events/__tests__/control-mode-client.test.ts
+++ b/packages/vscode/src/events/__tests__/control-mode-client.test.ts
@@ -12,6 +12,7 @@ import {
     ControlModeClient,
     CONTROL_MODE_RETRY_BASE_MS,
     CONTROL_MODE_MAX_RETRIES,
+    CONTROL_MODE_FORCE_KILL_GRACE_MS,
     type ControlModeEvent,
 } from '../control-mode-client';
 
@@ -153,6 +154,29 @@ describe('ControlModeClient', () => {
         client.dispose();
     });
 
+    it('dispose() 後、猶予時間内に exit しないプロセスは SIGKILL で強制終了すること', () => {
+        const { client } = createClient();
+        client.start();
+        client.dispose();
+        expect(fakeProc.kill).toHaveBeenCalledTimes(1);
+
+        // exit イベントが来ないまま猶予時間が経過
+        vi.advanceTimersByTime(CONTROL_MODE_FORCE_KILL_GRACE_MS);
+        expect(fakeProc.kill).toHaveBeenCalledTimes(2);
+        expect(fakeProc.kill).toHaveBeenLastCalledWith('SIGKILL');
+    });
+
+    it('dispose() 後、猶予時間内に exit すれば強制終了しないこと', () => {
+        const { client } = createClient();
+        client.start();
+        client.dispose();
+        expect(fakeProc.kill).toHaveBeenCalledTimes(1);
+
+        fakeProc.emit('exit', 0);
+        vi.advanceTimersByTime(CONTROL_MODE_FORCE_KILL_GRACE_MS * 2);
+        expect(fakeProc.kill).toHaveBeenCalledTimes(1);
+    });
+
     it('dispose() でプロセスを kill し再起動しないこと', () => {
         const { client } = createClient();
         client.start();
@@ -162,6 +186,36 @@ describe('ControlModeClient', () => {
         fakeProc.emit('exit', 0);
         vi.advanceTimersByTime(CONTROL_MODE_RETRY_BASE_MS * 10);
         expect(spawnMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('error イベント単独（exit なし）でもバックオフ後に再接続すること', () => {
+        const { client } = createClient();
+        client.start();
+        expect(spawnMock).toHaveBeenCalledTimes(1);
+
+        const nextProc = new FakeProcess();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        spawnMock.mockImplementation(() => nextProc as any);
+
+        fakeProc.emit('error', new Error('spawn ENOENT'));
+        vi.advanceTimersByTime(CONTROL_MODE_RETRY_BASE_MS);
+        expect(spawnMock).toHaveBeenCalledTimes(2);
+        client.dispose();
+    });
+
+    it('error と exit が両方発火しても再接続は1回だけであること', () => {
+        const { client } = createClient();
+        client.start();
+
+        const nextProc = new FakeProcess();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        spawnMock.mockImplementation(() => nextProc as any);
+
+        fakeProc.emit('error', new Error('boom'));
+        fakeProc.emit('exit', 1);
+        vi.advanceTimersByTime(CONTROL_MODE_RETRY_BASE_MS * 4);
+        expect(spawnMock).toHaveBeenCalledTimes(2);
+        client.dispose();
     });
 
     it('プロセスが予期せず終了したらバックオフ後に再接続すること', () => {

--- a/packages/vscode/src/events/__tests__/tmux-watcher-recovery.test.ts
+++ b/packages/vscode/src/events/__tests__/tmux-watcher-recovery.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// vscode は型参照のみのため空モック
+vi.mock('vscode', () => ({}));
+vi.mock('../../ui/agent-panel-provider', () => ({}));
+
+// ControlModeClient をモックし、onFatal を任意タイミングで発火できるようにする
+const { clientInstances } = vi.hoisted(() => ({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    clientInstances: [] as any[],
+}));
+
+vi.mock('../control-mode-client', () => {
+    class FakeControlModeClient {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        public options: any;
+        public start = vi.fn();
+        public dispose = vi.fn();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        constructor(options: any) {
+            this.options = options;
+            clientInstances.push(this);
+        }
+    }
+    return { ControlModeClient: FakeControlModeClient };
+});
+
+import {
+    createTmuxWatcherState,
+    startTmuxWindowWatching,
+    stopTmuxWindowPolling,
+    disposeTmuxWatcher,
+    CONTROL_MODE_REATTEMPT_MS,
+    type TmuxWatcherContext,
+    type TmuxWatcherState,
+} from '../tmux-watcher';
+import { Agent } from '../../types';
+
+function createContext(): TmuxWatcherContext {
+    const agents = new Map<string, Agent>();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    agents.set('emma', {} as any);
+    return {
+        agents,
+        tmuxManager: {
+            getControlModeSpawn: vi.fn(() => ({
+                command: 'wsl',
+                args: ['tmux', '-C', 'attach-session', '-t', 'maid-session'],
+            })),
+            getCurrentWindowName: vi.fn(() => 'emma'),
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        tmuxSessionName: 'maid-session',
+        tmuxViewerTerminal: undefined,
+        agentPanelProvider: undefined,
+        log: vi.fn(),
+    };
+}
+
+describe('tmux-watcher control mode 自己回復', () => {
+    let ctx: TmuxWatcherContext;
+    let state: TmuxWatcherState;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        clientInstances.length = 0;
+        ctx = createContext();
+        state = createTmuxWatcherState();
+    });
+
+    afterEach(() => {
+        disposeTmuxWatcher(state);
+        vi.useRealTimers();
+    });
+
+    it('onFatal 後はポーリングにフォールバックすること', () => {
+        startTmuxWindowWatching(ctx, state);
+        expect(clientInstances).toHaveLength(1);
+
+        clientInstances[0].options.onFatal();
+        expect(state.pollingInterval).toBeDefined();
+
+        // ポーリングが実際に動作している
+        vi.advanceTimersByTime(500);
+        expect(ctx.tmuxManager?.getCurrentWindowName).toHaveBeenCalled();
+    });
+
+    it('フォールバック後、クールダウン経過で control mode を再試行すること', () => {
+        startTmuxWindowWatching(ctx, state);
+        clientInstances[0].options.onFatal();
+        expect(state.pollingInterval).toBeDefined();
+
+        vi.advanceTimersByTime(CONTROL_MODE_REATTEMPT_MS);
+
+        // ポーリングが止まり、新しい control mode クライアントが起動している
+        expect(state.pollingInterval).toBeUndefined();
+        expect(clientInstances).toHaveLength(2);
+        expect(clientInstances[1].start).toHaveBeenCalled();
+    });
+
+    it('再試行した control mode が再度失敗しても、再びフォールバック＋次の再試行が予約されること', () => {
+        startTmuxWindowWatching(ctx, state);
+        clientInstances[0].options.onFatal();
+        vi.advanceTimersByTime(CONTROL_MODE_REATTEMPT_MS);
+        expect(clientInstances).toHaveLength(2);
+
+        clientInstances[1].options.onFatal();
+        expect(state.pollingInterval).toBeDefined();
+
+        vi.advanceTimersByTime(CONTROL_MODE_REATTEMPT_MS);
+        expect(clientInstances).toHaveLength(3);
+    });
+
+    it('監視停止中はクールダウンが経過しても再試行しないこと', () => {
+        startTmuxWindowWatching(ctx, state);
+        clientInstances[0].options.onFatal();
+
+        stopTmuxWindowPolling(ctx, state);
+        vi.advanceTimersByTime(CONTROL_MODE_REATTEMPT_MS * 2);
+
+        expect(clientInstances).toHaveLength(1);
+        expect(state.pollingInterval).toBeUndefined();
+    });
+
+    it('disposeTmuxWatcher で再試行タイマーもクリアされること', () => {
+        startTmuxWindowWatching(ctx, state);
+        clientInstances[0].options.onFatal();
+
+        disposeTmuxWatcher(state);
+        vi.advanceTimersByTime(CONTROL_MODE_REATTEMPT_MS * 2);
+
+        expect(clientInstances).toHaveLength(1);
+    });
+
+    it('監視の再開時（stop→start）は失敗履歴に関係なく control mode を優先すること', () => {
+        startTmuxWindowWatching(ctx, state);
+        clientInstances[0].options.onFatal();
+        stopTmuxWindowPolling(ctx, state);
+
+        startTmuxWindowWatching(ctx, state);
+        expect(clientInstances).toHaveLength(2);
+        expect(clientInstances[1].start).toHaveBeenCalled();
+    });
+});

--- a/packages/vscode/src/events/control-mode-client.ts
+++ b/packages/vscode/src/events/control-mode-client.ts
@@ -20,6 +20,9 @@ export const CONTROL_MODE_RETRY_MAX_MS = 30000;
 /** 連続失敗の上限。超えたら onFatal を呼び、呼び出し側はポーリングへフォールバック */
 export const CONTROL_MODE_MAX_RETRIES = 5;
 
+/** dispose 後、プロセスの exit を待つ猶予（ms）。超過したら SIGKILL で強制終了 */
+export const CONTROL_MODE_FORCE_KILL_GRACE_MS = 3000;
+
 /**
  * control mode 出力のパース結果
  */
@@ -149,24 +152,49 @@ export class ControlModeClient {
         this.proc = proc;
 
         proc.stdout?.on('data', (chunk: Buffer | string) => this.handleData(chunk));
+
+        // exit と error の二重発火を防ぎつつ、error 単独（spawn 失敗等で exit が来ない）でも
+        // 再接続・フォールバック経路に乗せる
+        let downHandled = false;
+        const onDown = (): void => {
+            if (downHandled) return;
+            downHandled = true;
+            this.handleExit();
+        };
         proc.on('error', (err: Error) => {
             this.log(`control mode spawn error: ${err.message}`);
+            onDown();
         });
-        proc.on('exit', () => this.handleExit());
+        proc.on('exit', onDown);
 
         // 初期状態の取得（接続直後の現在ウィンドウ名）
         this.queryCurrentWindow();
     }
 
     private killProcess(): void {
-        if (this.proc) {
-            try {
-                this.proc.kill();
-            } catch (err) {
-                this.log(`control mode kill failed: ${err instanceof Error ? err.message : String(err)}`);
-            }
-            this.proc = undefined;
+        if (!this.proc) return;
+        const proc = this.proc;
+        this.proc = undefined;
+
+        try {
+            proc.kill();
+        } catch (err) {
+            this.log(`control mode kill failed: ${err instanceof Error ? err.message : String(err)}`);
         }
+
+        // 猶予時間内に exit しない場合は強制終了（wsl.exe 残留＝宙ぶらりんプロセスの防止）
+        const forceKillTimer = setTimeout(() => {
+            try {
+                proc.kill('SIGKILL');
+                this.log('control mode: プロセスが終了しないため強制終了しました');
+            } catch (err) {
+                this.log(`control mode force kill failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }, CONTROL_MODE_FORCE_KILL_GRACE_MS);
+        // exit したらエスカレーション不要
+        proc.once('exit', () => clearTimeout(forceKillTimer));
+        // タイマーがプロセス終了を妨げないようにする（テスト環境では unref が無い場合がある）
+        forceKillTimer.unref?.();
     }
 
     /**

--- a/packages/vscode/src/events/tmux-watcher.ts
+++ b/packages/vscode/src/events/tmux-watcher.ts
@@ -17,6 +17,9 @@ import { ITerminalMultiplexer } from '../multiplexer';
 import { AgentPanelProvider } from '../ui/agent-panel-provider';
 import { ControlModeClient } from './control-mode-client';
 
+/** control mode フォールバック後に再試行するまでのクールダウン（ms） */
+export const CONTROL_MODE_REATTEMPT_MS = 5 * 60 * 1000;
+
 /**
  * tmux監視に必要なコンテキスト
  */
@@ -37,8 +40,10 @@ export interface TmuxWatcherState {
     lastDetectedAgentId: string | null;
     /** control mode 常駐クライアント（イベント駆動監視） */
     controlModeClient: ControlModeClient | undefined;
-    /** control mode が失敗しポーリングへ恒久フォールバックしたか */
+    /** control mode が失敗しポーリングへフォールバック中か（クールダウン後に自動再試行） */
     controlModeFailed: boolean;
+    /** control mode 再試行のクールダウンタイマー */
+    controlModeRetryTimer: NodeJS.Timeout | undefined;
 }
 
 /**
@@ -50,6 +55,7 @@ export function createTmuxWatcherState(): TmuxWatcherState {
         lastDetectedAgentId: null,
         controlModeClient: undefined,
         controlModeFailed: false,
+        controlModeRetryTimer: undefined,
     };
 }
 
@@ -167,15 +173,44 @@ export function startTmuxWindowWatching(
         onWindowName: (name) => handleDetectedWindowName(ctx, state, name),
         onLog: (msg) => ctx.log(msg),
         onFatal: () => {
-            // control mode が使えない環境ではポーリングへフォールバック
+            // control mode が使えない間はポーリングへフォールバックし、
+            // クールダウン後に control mode を自動再試行する（自己回復）
             ctx.log('[tmux] control mode が利用できないためポーリングへフォールバックします');
             state.controlModeFailed = true;
             state.controlModeClient = undefined;
             startTmuxWindowPolling(ctx, state);
+            scheduleControlModeReattempt(ctx, state);
         },
     });
     state.controlModeClient.start();
     ctx.log('[tmux] control mode によるウィンドウ監視を開始（イベント駆動）');
+}
+
+/**
+ * クールダウン後に control mode の再試行を予約する
+ *
+ * 一過性の失敗（wsl の一時停止等）でプロセス生成型ポーリングが
+ * セッション中恒久化しないようにするための自己回復機構。
+ */
+function scheduleControlModeReattempt(
+    ctx: TmuxWatcherContext,
+    state: TmuxWatcherState
+): void {
+    if (state.controlModeRetryTimer) return; // 既に予約済み
+
+    state.controlModeRetryTimer = setTimeout(() => {
+        state.controlModeRetryTimer = undefined;
+
+        // 監視自体が停止していたら何もしない（次回の監視開始時に control mode を優先する）
+        if (!state.pollingInterval) return;
+
+        ctx.log('[tmux] control mode を再試行します（ポーリングから復帰）');
+        clearInterval(state.pollingInterval);
+        state.pollingInterval = undefined;
+        state.controlModeFailed = false;
+        startTmuxWindowWatching(ctx, state);
+    }, CONTROL_MODE_REATTEMPT_MS);
+    state.controlModeRetryTimer.unref?.();
 }
 
 /**
@@ -216,6 +251,12 @@ export function stopTmuxWindowPolling(
         state.pollingInterval = undefined;
         stopped = true;
     }
+    if (state.controlModeRetryTimer) {
+        clearTimeout(state.controlModeRetryTimer);
+        state.controlModeRetryTimer = undefined;
+    }
+    // 次回の監視開始時は control mode を改めて優先する
+    state.controlModeFailed = false;
     if (stopped) {
         state.lastDetectedAgentId = null;
         ctx.log('[tmux] ウィンドウ監視を停止');
@@ -234,5 +275,10 @@ export function disposeTmuxWatcher(state: TmuxWatcherState): void {
         clearInterval(state.pollingInterval);
         state.pollingInterval = undefined;
     }
+    if (state.controlModeRetryTimer) {
+        clearTimeout(state.controlModeRetryTimer);
+        state.controlModeRetryTimer = undefined;
+    }
+    state.controlModeFailed = false;
     state.lastDetectedAgentId = null;
 }


### PR DESCRIPTION
## 背景

PR #21 レビューでのエマの SHOULD 指摘対応:
- `controlModeFailed` が恒久固定で、一過性の失敗（wsl一時停止等）でもセッション中プロセス生成型ポーリングに戻ったままになる

また、PR #21 反映後の実機確認で `wsl tmux -C attach-session` プロセスが2本存在する事象（片方は生きているtmuxクライアントを持たない宙ぶらりん）を観測したため、dispose の kill 堅牢化も同スコープで対応。

## 変更内容

- **tmux-watcher.ts**: フォールバック後 **5分のクールダウンで control mode を自動再試行**（自己回復）。監視停止時は failed フラグ・再試行タイマーをリセットし、次回の監視開始時も control mode を優先
- **control-mode-client.ts**:
  - dispose 後 **3秒で exit しないプロセスを SIGKILL**（宙ぶらりん wsl.exe の残留防止）
  - `error` イベント単独（exit が来ない spawn 失敗等）でも再接続・フォールバック経路に乗るよう exit/error ハンドリングを一本化（従来は無音で死ぬ穴があった）

## テスト

- TDD（テスト先行コミット 9b74519 → 実装 d544ac3）
- 新規10テスト追加（自己回復6件 / dispose堅牢化2件 / error経路2件）、計26件全通過
- 既存テスト退行ゼロ（devベースラインの既存失敗25件は変更前後で同一・本変更と無関係）
- `npm run compile:tsc` / `npm run compile`（esbuild）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2HGmiUnMfpqXFeF5AaL6D