### PR TITLE
fix(task-1660-1): 起動時のMaid Agentタブ重複生成を修正

### DIFF
--- a/packages/vscode/src/__tests__/controller.test.ts
+++ b/packages/vscode/src/__tests__/controller.test.ts
@@ -23,6 +23,7 @@ vi.mock('vscode', () => ({
         showWarningMessage: vi.fn(() => Promise.resolve(undefined)),
         showInputBox: vi.fn(() => Promise.resolve(undefined)),
         showQuickPick: vi.fn(() => Promise.resolve(undefined)),
+        terminals: [] as unknown[],
         createTerminal: vi.fn(() => ({
             show: vi.fn(),
             sendText: vi.fn(),
@@ -75,6 +76,13 @@ vi.mock('../utils/environment', () => ({
         quoteCommandArg: (v: string) => `'${v}'`,
         setRuntimeMode: vi.fn(),
         getRuntimeMode: vi.fn(() => undefined),
+        getTerminalFactory: vi.fn(() => ({
+            createViewerTerminal: vi.fn(() => ({
+                show: vi.fn(),
+                sendText: vi.fn(),
+                dispose: vi.fn(),
+            })),
+        })),
     },
 }));
 

--- a/packages/vscode/src/agents/__tests__/agent-startup-tmux-viewer.test.ts
+++ b/packages/vscode/src/agents/__tests__/agent-startup-tmux-viewer.test.ts
@@ -1,0 +1,113 @@
+/**
+ * openTmuxViewer() の既存タブ再利用テスト（task-1660-1）
+ *
+ * 起動時（拡張機能再アクティベート時）、メモリ内参照(ctx.tmuxViewerTerminal)は
+ * 失われるが VSCode 上には前回作成した 'Maid Agent' タブが実在するケースで、
+ * 新規タブを作らず既存タブを再利用することを検証する。
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('vscode', () => ({
+    window: {
+        terminals: [] as Array<{ name: string; show: ReturnType<typeof vi.fn> }>,
+        createTerminal: vi.fn(() => ({
+            name: '🎩 Maid Agent (tmux)',
+            show: vi.fn(),
+            sendText: vi.fn(),
+            dispose: vi.fn(),
+        })),
+    },
+}));
+
+const createViewerTerminalMock = vi.fn(() => ({
+    name: '🎩 Maid Agent (tmux)',
+    show: vi.fn(),
+    dispose: vi.fn(),
+}));
+
+vi.mock('../../utils/environment', () => ({
+    ENV: {
+        getTerminalFactory: vi.fn(() => ({
+            createViewerTerminal: createViewerTerminalMock,
+        })),
+    },
+}));
+
+import * as vscode from 'vscode';
+import { openTmuxViewer } from '../agent-startup';
+import type { AgentContext } from '../../types';
+
+function createMockContext(overrides: Partial<AgentContext> = {}): AgentContext {
+    return {
+        tmuxManager: { createSession: vi.fn() } as unknown as AgentContext['tmuxManager'],
+        multiplexerFactory: { getType: () => 'tmux' } as unknown as AgentContext['multiplexerFactory'],
+        tmuxSessionName: 'maid-agent-test',
+        tmuxViewerTerminal: undefined,
+        workspaceRoot: '/test/workspace',
+        settings: undefined,
+        initializeTmuxSession: vi.fn(),
+        log: vi.fn(),
+        ...overrides,
+    } as AgentContext;
+}
+
+describe('openTmuxViewer - 既存タブ再利用', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (vscode.window as unknown as { terminals: unknown[] }).terminals = [];
+    });
+
+    it('メモリ内参照・実在タブのいずれもない場合は新規作成すること', () => {
+        const ctx = createMockContext();
+
+        openTmuxViewer(ctx);
+
+        expect(createViewerTerminalMock).toHaveBeenCalledTimes(1);
+        expect(ctx.tmuxViewerTerminal).toBeDefined();
+    });
+
+    it('実在するVSCodeタブ（同名）があれば再利用し、新規作成しないこと', () => {
+        const existingShow = vi.fn();
+        (vscode.window as unknown as { terminals: unknown[] }).terminals = [
+            { name: '🎩 Maid Agent (tmux)', show: existingShow },
+        ];
+        const ctx = createMockContext();
+
+        openTmuxViewer(ctx);
+
+        expect(createViewerTerminalMock).not.toHaveBeenCalled();
+        expect(existingShow).toHaveBeenCalledTimes(1);
+        expect(ctx.tmuxViewerTerminal).toBe(
+            (vscode.window as unknown as { terminals: Array<{ name: string }> }).terminals[0]
+        );
+    });
+
+    it('リロードを繰り返しても2回目以降は新規タブが増えないこと', () => {
+        const ctx1 = createMockContext();
+        openTmuxViewer(ctx1);
+        expect(createViewerTerminalMock).toHaveBeenCalledTimes(1);
+
+        // 拡張機能の再アクティベートを模し、メモリ内参照を失った新しい ctx を用意。
+        // ただし VSCode 上には直前に作成したタブが実在する状態。
+        (vscode.window as unknown as { terminals: unknown[] }).terminals = [
+            ctx1.tmuxViewerTerminal as unknown as { name: string },
+        ];
+        const ctx2 = createMockContext();
+
+        openTmuxViewer(ctx2);
+
+        expect(createViewerTerminalMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('ctx.tmuxViewerTerminal（メモリ内参照）があれば最優先で再利用すること', () => {
+        const memoryShow = vi.fn();
+        const ctx = createMockContext({
+            tmuxViewerTerminal: { name: 'memory-ref', show: memoryShow } as unknown as AgentContext['tmuxViewerTerminal'],
+        });
+
+        openTmuxViewer(ctx);
+
+        expect(memoryShow).toHaveBeenCalledTimes(1);
+        expect(createViewerTerminalMock).not.toHaveBeenCalled();
+    });
+});

--- a/packages/vscode/src/agents/agent-startup.ts
+++ b/packages/vscode/src/agents/agent-startup.ts
@@ -175,14 +175,11 @@ export function saveSessionNameToFile(ctx: AgentContext): void {
 export function openTmuxViewer(ctx: AgentContext): void {
     if (!ctx.tmuxManager) return;
 
-    // 既存のビューアがあれば表示
+    // 既存のビューアがあれば表示（メモリ内参照）
     if (ctx.tmuxViewerTerminal) {
         ctx.tmuxViewerTerminal.show();
         return;
     }
-
-    // tmuxセッションがなければ作成
-    ctx.initializeTmuxSession();
 
     // マルチプレクサタイプを取得（設定 > ファクトリ > auto の優先順）
     let multiplexerType = ctx.settings?.multiplexer?.type;
@@ -190,9 +187,23 @@ export function openTmuxViewer(ctx: AgentContext): void {
         multiplexerType = ctx.multiplexerFactory?.getType() || 'auto';
     }
     const isPsmux = multiplexerType === 'psmux';
+    const terminalName = isPsmux ? '🎩 Maid Agent (psmux)' : '🎩 Maid Agent (tmux)';
+
+    // VSCode上に実在する同名タブがあれば再利用する。
+    // 拡張機能の再アクティベート（ウィンドウリロード等）でメモリ内参照
+    // (ctx.tmuxViewerTerminal) は失われるが、タブ自体は残っているため、
+    // ここでチェックしないと毎回新規タブが積み上がる（task-1660-1）。
+    const existingTerminal = vscode.window.terminals.find((t) => t.name === terminalName);
+    if (existingTerminal) {
+        ctx.tmuxViewerTerminal = existingTerminal;
+        existingTerminal.show();
+        return;
+    }
+
+    // tmuxセッションがなければ作成
+    ctx.initializeTmuxSession();
 
     // VSCodeターミナルでtmux/psmuxにアタッチ（TerminalFactory経由で環境分岐を統一）
-    const terminalName = isPsmux ? '🎩 Maid Agent (psmux)' : '🎩 Maid Agent (tmux)';
     const terminalFactory = ENV.getTerminalFactory(isPsmux);
     ctx.tmuxViewerTerminal = terminalFactory.createViewerTerminal(
         terminalName,


### PR DESCRIPTION
## 概要

起動時（拡張機能の再アクティベート・ウィンドウリロード等）に既存の'Maid Agent'ターミナルタブの有無を確認せず、毎回新規タブを生成していた問題を修正。

## 原因

`openTmuxViewer()`（`packages/vscode/src/agents/agent-startup.ts`）は `ctx.tmuxViewerTerminal`（メモリ内参照）のみで既存タブの有無を判定していた。拡張機能が再アクティベートされるとコントローラーインスタンスが新規になり、この参照は常に`undefined`から始まる。そのためVSCode上にタブが実在していても検知できず、`vscode.window.createTerminal`が毎回新規呼び出しされてタブが積み上がっていた。

## 修正内容

- `openTmuxViewer()`に、`vscode.window.terminals`から同名タブ（`🎩 Maid Agent (tmux/psmux)`）を検索し、存在すれば再利用するチェックを追加
- 既存タブがなければ従来通り新規作成
- `tmuxManager.createSession()`は元々冪等（`sessionExists()`確認済み）のため、チェック順序の変更による副作用なし

## 完了条件（対応状況）

- [x] Windsurfリロード時に既存のMaid Agentタブがあれば再利用されること
- [x] タブが存在しない場合は従来通り新規作成されること
- [x] リロードを繰り返してもタブが溜まらないこと

## テスト

`packages/vscode/src/agents/__tests__/agent-startup-tmux-viewer.test.ts` を新規作成（TDD）。以下4ケースを検証:
1. メモリ内参照・実在タブいずれもない場合は新規作成
2. 実在するVSCodeタブ（同名）があれば再利用し新規作成しないこと
3. リロードを繰り返しても2回目以降は新規タブが増えないこと
4. メモリ内参照があれば最優先で再利用すること

既存の `controller.test.ts` の `vscode` / `ENV` モックに `window.terminals` / `getTerminalFactory` が未定義だったため補完（実際のAPI形状に合わせた修正で、テスト内容自体は変更なし）。

- `npx vitest run --changed HEAD`: 新規4件 + 関連59件中 changed分は全pass（`watchdog-launch-command-parity.test.ts`の失敗17件は本変更と無関係な既存の環境依存問題であることをdev HEAD上で確認済み。`/tmp/.maid-agent/system/bin/watchdog.sh`が見つからないローカル環境要因）
- `npx tsc --noEmit`: エラーなし
- `npm run compile`（esbuild）: ビルド成功

## 参照

task-1660-1（改善提案task-1660由来）

🤖 Generated with [Claude Code](https://claude.com/claude-code)