### PR TITLE
fix(task-1641-1): LLM品質チェックのファイル解決にworktreeパス対応を追加

### DIFF
--- a/global-templates/bin/maidctl
+++ b/global-templates/bin/maidctl
@@ -1066,6 +1066,32 @@ cmd_my_task() {
 # 品質チェック関数
 # =============================================================================
 
+# 現在の作業ディレクトリが git の linked worktree（git worktree add で作成された
+# worktree。主working treeではない）かどうかを判定し、そのルート絶対パスを返す。
+# 主working tree内やgit管理外のディレクトリの場合は何も出力しない（空文字扱い）。
+#
+# 判定方法: --git-dir（現在のworktree固有のgitディレクトリ）と --git-common-dir
+# （全worktreeで共有される本来の.git）を比較し、一致しない場合のみ linked worktree
+# と判定する（主working treeでは両者が一致する）。
+detect_linked_worktree_root() {
+  local cwd
+  cwd="$(pwd)"
+
+  if ! git -C "$cwd" rev-parse --is-inside-work-tree &>/dev/null; then
+    return 0  # git管理外。worktree_rootなしとして扱う
+  fi
+
+  local git_dir git_common_dir
+  git_dir=$(git -C "$cwd" rev-parse --path-format=absolute --git-dir 2>/dev/null) || return 0
+  git_common_dir=$(git -C "$cwd" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 0
+
+  if [ "$git_dir" = "$git_common_dir" ]; then
+    return 0  # 主working tree（linked worktreeではない）
+  fi
+
+  git -C "$cwd" rev-parse --show-toplevel 2>/dev/null
+}
+
 # 品質チェックを実行
 # 引数: agent_id
 # 戻り値: 0=合格, 2=不合格
@@ -1078,6 +1104,9 @@ quality_check() {
   local quality_script="$project_dir/.maid-agent/system/bin/quality-check.sh"
   local llm_script="$project_dir/.maid-agent/system/bin/quality-check-llm.sh"
   local settings_file="$project_dir/.maid-agent/system/config/settings.yaml"
+  # worktree運用時、実装ファイルが実際に存在するworktreeルート（linked worktree検出時のみ設定）
+  local worktree_root
+  worktree_root=$(detect_linked_worktree_root)
 
   # 品質チェックが有効かどうか確認
   # quality_check: セクション配下の enabled を明示的に抽出（他セクションとの混同を防止）
@@ -1127,7 +1156,7 @@ quality_check() {
   # L4: LLMチェック（追加）
   if [ -f "$llm_script" ]; then
     chmod +x "$llm_script" 2>/dev/null || true
-    if ! "$llm_script" "$report_file" "$task_type" "$project_dir"; then
+    if ! "$llm_script" "$report_file" "$task_type" "$project_dir" "$worktree_root"; then
       return 2  # Claude Code Hooks 互換: exit 2 でアクションブロック
     fi
   fi

--- a/global-templates/bin/test/maidctl-detect-linked-worktree.test.sh
+++ b/global-templates/bin/test/maidctl-detect-linked-worktree.test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# maidctl detect_linked_worktree_root テスト（task-1641-1）
+#
+# 背景: quality_check() 内のLLM品質チェックが、git worktree運用時に
+# worktreeではなく主working tree（メインリポジトリ）を参照して成果物評価を行い、
+# 「未実装」「report矛盾」の誤ったcritical判定を出す問題（task-1641改善提案）を修正する。
+# 本テストは、実際に quality_check() が使用する worktree検出ロジック
+# （detect_linked_worktree_root）を、実際に配布される maidctl から関数定義のみを
+# 抽出し、実物のgitリポジトリ・worktreeに対して検証する。
+#
+# quality-check-llm.sh / maid-agent-messenger APIへの worktreePath 伝播ロジックは
+# packages/maid-agent-messenger/src/services/__tests__/quality-service-worktree.test.ts
+# で別途検証済み。
+#
+# 完了条件:
+#   - git管理外ディレクトリ → 空文字（worktree_rootなし）
+#   - 主working tree（通常のgitリポジトリ/clone） → 空文字（linked worktreeではない）
+#   - linked worktree（git worktree add で作成） → worktreeの絶対パスを返す
+#
+# 実行: bash global-templates/bin/test/maidctl-detect-linked-worktree.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAIDCTL_SOURCE="${SCRIPT_DIR}/../maidctl"
+
+pass=0
+fail=0
+
+# --- detect_linked_worktree_root 関数定義のみを実際の maidctl から抽出 ---
+FUNC_SRC="$(sed -n '/^detect_linked_worktree_root() {/,/^}/p' "${MAIDCTL_SOURCE}")"
+if [[ -z "${FUNC_SRC}" ]]; then
+  echo "FAIL: detect_linked_worktree_root 関数が ${MAIDCTL_SOURCE} に見つかりません"
+  exit 1
+fi
+
+SANDBOX="$(mktemp -d)"
+cleanup() {
+  rm -rf "${SANDBOX}"
+}
+trap cleanup EXIT
+
+run_in_dir() {
+  local dir="$1"
+  (
+    cd "${dir}" || exit 1
+    eval "${FUNC_SRC}"
+    detect_linked_worktree_root
+  )
+}
+
+assert_empty() {
+  local label="$1" dir="$2"
+  local output
+  output="$(run_in_dir "${dir}")"
+  if [[ -z "${output}" ]]; then
+    echo "PASS: ${label}"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: ${label}"
+    echo "  expected: (空文字)"
+    echo "  actual:   ${output}"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_equals() {
+  local label="$1" expected="$2" dir="$3"
+  local output
+  output="$(run_in_dir "${dir}")"
+  if [[ "${output}" == "${expected}" ]]; then
+    echo "PASS: ${label}"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: ${label}"
+    echo "  expected: ${expected}"
+    echo "  actual:   ${output}"
+    fail=$((fail + 1))
+  fi
+}
+
+echo "=== maidctl detect_linked_worktree_root tests ==="
+echo ""
+
+# -----------------------------------------------------------------------
+# git管理外ディレクトリ → 空文字
+# -----------------------------------------------------------------------
+NON_GIT_DIR="${SANDBOX}/non-git"
+mkdir -p "${NON_GIT_DIR}"
+assert_empty "git管理外ディレクトリ → worktree_rootなし（空文字）" "${NON_GIT_DIR}"
+
+# -----------------------------------------------------------------------
+# 主working tree（通常のgitリポジトリ） → 空文字（linked worktreeではない）
+# -----------------------------------------------------------------------
+MAIN_REPO="${SANDBOX}/main-repo"
+mkdir -p "${MAIN_REPO}"
+git -C "${MAIN_REPO}" init -q -b dev
+git -C "${MAIN_REPO}" config user.name "test"
+git -C "${MAIN_REPO}" config user.email "test@example.com"
+echo "hello" > "${MAIN_REPO}/file.txt"
+git -C "${MAIN_REPO}" add file.txt
+git -C "${MAIN_REPO}" commit -q -m "init"
+assert_empty "主working tree（通常clone） → worktree_rootなし（空文字）" "${MAIN_REPO}"
+
+# -----------------------------------------------------------------------
+# linked worktree（git worktree add で作成） → worktreeの絶対パスを返す
+# -----------------------------------------------------------------------
+LINKED_WT="${SANDBOX}/linked-worktree"
+git -C "${MAIN_REPO}" worktree add -q -b feature/test-branch "${LINKED_WT}" dev >/dev/null 2>&1
+EXPECTED_WT_PATH="$(cd "${LINKED_WT}" && pwd)"
+assert_equals "linked worktree → worktreeの絶対パスを返す" "${EXPECTED_WT_PATH}" "${LINKED_WT}"
+
+echo ""
+echo "Results: ${pass} passed, ${fail} failed"
+[[ ${fail} -eq 0 ]]

--- a/global-templates/maid-agent-messenger/dist/routes/quality-routes.js
+++ b/global-templates/maid-agent-messenger/dist/routes/quality-routes.js
@@ -19,7 +19,7 @@ router.post("/api/quality/llm-check", async (req, res) => {
     try {
         const projectPath = getProjectPathFromRequest(req);
         const body = req.body;
-        const { taskId, taskType, reportContent, agentId, options } = body;
+        const { taskId, taskType, reportContent, agentId, worktreePath, options } = body;
         // バリデーション
         if (!taskId || !taskType || !reportContent) {
             res.status(400).json({
@@ -73,6 +73,7 @@ router.post("/api/quality/llm-check", async (req, res) => {
                 const fileContents = await readFileContentsForReview(projectPath, changedFiles, {
                     maxLinesPerFile: llmConfig.max_lines_per_file || 300,
                     maxTotalLines: llmConfig.max_total_lines || 1500,
+                    worktreePath,
                 });
                 logger.debug(`Read ${fileContents.length} files for review`);
                 fullPrompt = buildPromptWithFileContents(prompt, reportContent, fileContents);

--- a/global-templates/maid-agent-messenger/dist/services/quality-service.d.ts
+++ b/global-templates/maid-agent-messenger/dist/services/quality-service.d.ts
@@ -81,6 +81,12 @@ export interface FileContent {
 export interface FileReadOptions {
     maxLinesPerFile?: number;
     maxTotalLines?: number;
+    /**
+     * worktree運用時、実装ファイルが実際に存在するworktreeルートの絶対パス。
+     * 報告書の変更ファイルパスにリポジトリ名prefixが含まれる場合（例:
+     * "codelodis/packages/foo.ts"）でも解決できるよう、prefix除去版も候補に含める。
+     */
+    worktreePath?: string;
 }
 /**
  * 報告書から変更ファイルパスを抽出

--- a/global-templates/maid-agent-messenger/dist/services/quality-service.js
+++ b/global-templates/maid-agent-messenger/dist/services/quality-service.js
@@ -125,6 +125,53 @@ export async function recordIssueClassification(projectPath, taskId, reason, cla
 const DEFAULT_MAX_LINES_PER_FILE = 300;
 const DEFAULT_MAX_TOTAL_LINES = 1500;
 /**
+ * base配下（base自身を含む）にtargetが収まっているか判定する
+ */
+function isWithinBase(base, target) {
+    return target === base || target.startsWith(base + path.sep);
+}
+/**
+ * 変更ファイルパスの解決候補を優先順位順に構築する
+ *
+ * 相対パスの場合、worktreePathが指定されていれば以下の順で候補を作る:
+ *   1. worktreeルート直下（filePathそのまま）
+ *   2. worktreeルート直下（先頭セグメント＝リポジトリ名prefixを除去）
+ *   3. projectPath基準（従来通り）
+ *
+ * 絶対パスの場合はprojectPath配下かどうかのみを検証する（従来通り）。
+ * 各候補はbase外へ逸脱していないことを個別に検証済みのもののみ返す
+ * （パストラバーサル防止）。
+ */
+function buildFilePathCandidates(projectPath, worktreePath, filePath) {
+    const normalizedProjectPath = path.normalize(projectPath);
+    if (path.isAbsolute(filePath)) {
+        const absolutePath = path.normalize(filePath);
+        return isWithinBase(normalizedProjectPath, absolutePath)
+            ? [{ absolutePath, base: normalizedProjectPath }]
+            : [];
+    }
+    const candidates = [];
+    if (worktreePath) {
+        const normalizedWorktreePath = path.normalize(worktreePath);
+        const direct = path.normalize(path.join(normalizedWorktreePath, filePath));
+        if (isWithinBase(normalizedWorktreePath, direct)) {
+            candidates.push({ absolutePath: direct, base: normalizedWorktreePath });
+        }
+        const segments = filePath.split("/");
+        if (segments.length > 1) {
+            const stripped = path.normalize(path.join(normalizedWorktreePath, segments.slice(1).join("/")));
+            if (isWithinBase(normalizedWorktreePath, stripped)) {
+                candidates.push({ absolutePath: stripped, base: normalizedWorktreePath });
+            }
+        }
+    }
+    const fromProject = path.normalize(path.join(normalizedProjectPath, filePath));
+    if (isWithinBase(normalizedProjectPath, fromProject)) {
+        candidates.push({ absolutePath: fromProject, base: normalizedProjectPath });
+    }
+    return candidates;
+}
+/**
  * 報告書から変更ファイルパスを抽出
  * 「## 変更ファイル」セクションをパースする
  */
@@ -165,6 +212,7 @@ export function extractChangedFilesFromReport(reportContent) {
 export async function readFileContentsForReview(projectPath, filePaths, options = {}) {
     const maxLinesPerFile = options.maxLinesPerFile || DEFAULT_MAX_LINES_PER_FILE;
     const maxTotalLines = options.maxTotalLines || DEFAULT_MAX_TOTAL_LINES;
+    const worktreePath = options.worktreePath;
     const results = [];
     let totalLines = 0;
     for (const filePath of filePaths) {
@@ -178,15 +226,9 @@ export async function readFileContentsForReview(projectPath, filePaths, options 
             });
             continue;
         }
-        // ファイルパスを解決（相対パス → 絶対パス）
-        // パストラバーサル防止: プロジェクトパス外へのアクセスを拒否
-        const normalizedProjectPath = path.normalize(projectPath);
-        const absolutePath = path.isAbsolute(filePath)
-            ? path.normalize(filePath)
-            : path.normalize(path.join(projectPath, filePath));
-        // プロジェクトパス外へのアクセスをチェック
-        if (!absolutePath.startsWith(normalizedProjectPath + path.sep) &&
-            absolutePath !== normalizedProjectPath) {
+        // ファイルパスの解決候補を構築（worktree優先 → projectPathの順。パストラバーサル防止込み）
+        const candidates = buildFilePathCandidates(projectPath, worktreePath, filePath);
+        if (candidates.length === 0) {
             results.push({
                 path: filePath,
                 content: "",
@@ -196,49 +238,58 @@ export async function readFileContentsForReview(projectPath, filePaths, options 
             });
             continue;
         }
-        try {
-            const content = await fs.readFile(absolutePath, "utf-8");
-            const lines = content.split("\n");
-            const lineCount = lines.length;
-            // 残り許容行数を計算
-            const remainingLines = maxTotalLines - totalLines;
-            const allowedLines = Math.min(maxLinesPerFile, remainingLines);
-            if (lineCount <= allowedLines) {
-                // 全文を含める
-                results.push({
-                    path: filePath,
-                    content: content,
-                    truncated: false,
-                    lineCount,
-                });
-                totalLines += lineCount;
+        // 候補を順に試行し、最初に読み込めたものを採用する
+        let content;
+        let lastError;
+        for (const candidate of candidates) {
+            try {
+                content = await fs.readFile(candidate.absolutePath, "utf-8");
+                break;
             }
-            else {
-                // 先頭と末尾を含め、中央を省略
-                const headLines = Math.floor(allowedLines / 2);
-                const tailLines = allowedLines - headLines;
-                const head = lines.slice(0, headLines).join("\n");
-                const tail = lines.slice(-tailLines).join("\n");
-                const omittedCount = lineCount - headLines - tailLines;
-                const truncatedContent = `${head}\n\n... (${omittedCount}行省略) ...\n\n${tail}`;
-                results.push({
-                    path: filePath,
-                    content: truncatedContent,
-                    truncated: true,
-                    lineCount,
-                });
-                totalLines += allowedLines;
+            catch (err) {
+                lastError = err;
             }
         }
-        catch (err) {
-            // ファイル読み込みエラー
+        if (content === undefined) {
             results.push({
                 path: filePath,
                 content: "",
                 truncated: false,
                 lineCount: 0,
-                error: err instanceof Error ? err.message : "Unknown error",
+                error: lastError instanceof Error ? lastError.message : "Unknown error",
             });
+            continue;
+        }
+        const lines = content.split("\n");
+        const lineCount = lines.length;
+        // 残り許容行数を計算
+        const remainingLines = maxTotalLines - totalLines;
+        const allowedLines = Math.min(maxLinesPerFile, remainingLines);
+        if (lineCount <= allowedLines) {
+            // 全文を含める
+            results.push({
+                path: filePath,
+                content: content,
+                truncated: false,
+                lineCount,
+            });
+            totalLines += lineCount;
+        }
+        else {
+            // 先頭と末尾を含め、中央を省略
+            const headLines = Math.floor(allowedLines / 2);
+            const tailLines = allowedLines - headLines;
+            const head = lines.slice(0, headLines).join("\n");
+            const tail = lines.slice(-tailLines).join("\n");
+            const omittedCount = lineCount - headLines - tailLines;
+            const truncatedContent = `${head}\n\n... (${omittedCount}行省略) ...\n\n${tail}`;
+            results.push({
+                path: filePath,
+                content: truncatedContent,
+                truncated: true,
+                lineCount,
+            });
+            totalLines += allowedLines;
         }
     }
     return results;

--- a/packages/maid-agent-messenger/src/routes/quality-routes.ts
+++ b/packages/maid-agent-messenger/src/routes/quality-routes.ts
@@ -35,6 +35,12 @@ interface LLMCheckRequest {
   taskType: string;
   reportContent: string;
   agentId?: string;
+  /**
+   * worktree運用時、実装ファイルが実際に存在するworktreeルートの絶対パス。
+   * 指定時、成果物評価（変更ファイル内容の読み込み）はworktreePathを優先して
+   * 解決を試み、見つからない場合はprojectPath基準にフォールバックする。
+   */
+  worktreePath?: string;
   options?: {
     model?: string;
     timeout?: number;
@@ -67,7 +73,7 @@ router.post("/api/quality/llm-check", async (req: Request, res: Response) => {
   try {
     const projectPath = getProjectPathFromRequest(req);
     const body = req.body as LLMCheckRequest;
-    const { taskId, taskType, reportContent, agentId, options } = body;
+    const { taskId, taskType, reportContent, agentId, worktreePath, options } = body;
 
     // バリデーション
     if (!taskId || !taskType || !reportContent) {
@@ -135,6 +141,7 @@ router.post("/api/quality/llm-check", async (req: Request, res: Response) => {
           {
             maxLinesPerFile: llmConfig.max_lines_per_file || 300,
             maxTotalLines: llmConfig.max_total_lines || 1500,
+            worktreePath,
           }
         );
         logger.debug(`Read ${fileContents.length} files for review`);

--- a/packages/maid-agent-messenger/src/services/__tests__/quality-service-worktree.test.ts
+++ b/packages/maid-agent-messenger/src/services/__tests__/quality-service-worktree.test.ts
@@ -1,0 +1,143 @@
+/**
+ * quality-service worktree パス対応テスト
+ *
+ * task-1641-1: maidctl set my-status completed 実行時のLLM品質チェックが
+ * worktreeパスを考慮せずメインリポジトリを参照している問題の修正を検証する。
+ *
+ * readFileContentsForReview に worktreePath オプションを渡した場合、
+ * 「リポジトリ名prefix付きの相対パス（例: codelodis/packages/foo.ts）」を
+ * worktreeルート配下（prefixを除去した上で）から優先的に解決できることを確認する。
+ */
+
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+
+// ESMモード: fs/promises をモック化
+const mockReadFile = jest.fn<(path: string, encoding: string) => Promise<string>>();
+
+jest.unstable_mockModule("fs/promises", () => ({
+  readFile: mockReadFile,
+}));
+
+// dynamic import（モック設定後に読み込み）
+const { readFileContentsForReview } = await import("../quality-service.js");
+
+const PROJECT_PATH = "/project";
+const WORKTREE_PATH = "/worktrees/task-1641-1";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("readFileContentsForReview - worktreePath 対応", () => {
+  it("worktreePath未指定時は従来通りprojectPath基準で解決する（後方互換）", async () => {
+    mockReadFile.mockImplementation(async (p: string) => {
+      if (p === "/project/packages/foo.ts") return "content-from-project";
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    const results = await readFileContentsForReview(PROJECT_PATH, [
+      "packages/foo.ts",
+    ]);
+
+    expect(results[0].content).toBe("content-from-project");
+    expect(results[0].error).toBeUndefined();
+  });
+
+  it("リポジトリ名prefix付きパスは、prefixを除去してworktreeルート配下から読み込む", async () => {
+    mockReadFile.mockImplementation(async (p: string) => {
+      // worktree側にのみ実装済み、メインリポジトリ側は未変更(devのまま)という状況を再現
+      if (p === "/worktrees/task-1641-1/packages/manager/foo.ts") {
+        return "content-from-worktree";
+      }
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    const results = await readFileContentsForReview(
+      PROJECT_PATH,
+      ["codelodis/packages/manager/foo.ts"],
+      { worktreePath: WORKTREE_PATH }
+    );
+
+    expect(results[0].content).toBe("content-from-worktree");
+    expect(results[0].error).toBeUndefined();
+    // メインリポジトリ側（未変更のdev）は参照されていないことを確認
+    expect(mockReadFile).not.toHaveBeenCalledWith(
+      "/project/codelodis/packages/manager/foo.ts",
+      expect.anything()
+    );
+  });
+
+  it("prefix無しパスもworktreeルート直下からまず試みる", async () => {
+    mockReadFile.mockImplementation(async (p: string) => {
+      if (p === "/worktrees/task-1641-1/src/foo.ts") return "content-from-worktree-root";
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    const results = await readFileContentsForReview(
+      PROJECT_PATH,
+      ["src/foo.ts"],
+      { worktreePath: WORKTREE_PATH }
+    );
+
+    expect(results[0].content).toBe("content-from-worktree-root");
+  });
+
+  it("worktree側に存在しないファイルはprojectPath側にフォールバックする", async () => {
+    mockReadFile.mockImplementation(async (p: string) => {
+      if (p === "/project/docs/readme.md") return "content-from-project-docs";
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    const results = await readFileContentsForReview(
+      PROJECT_PATH,
+      ["docs/readme.md"],
+      { worktreePath: WORKTREE_PATH }
+    );
+
+    expect(results[0].content).toBe("content-from-project-docs");
+    expect(results[0].error).toBeUndefined();
+  });
+
+  it("worktree側・projectPath側どちらにも存在しない場合はエラーを記録する", async () => {
+    mockReadFile.mockImplementation(async () => {
+      throw Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" });
+    });
+
+    const results = await readFileContentsForReview(
+      PROJECT_PATH,
+      ["codelodis/missing.ts"],
+      { worktreePath: WORKTREE_PATH }
+    );
+
+    expect(results[0].content).toBe("");
+    expect(results[0].error).toBeDefined();
+  });
+
+  it("プロジェクト外への絶対パスアクセスは引き続き拒否される（セキュリティ regression）", async () => {
+    const results = await readFileContentsForReview(
+      PROJECT_PATH,
+      ["/etc/passwd"],
+      { worktreePath: WORKTREE_PATH }
+    );
+
+    expect(results[0].error).toContain("Security");
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it("worktreePath外へのパストラバーサルは拒否され、他候補のみ試行される", async () => {
+    mockReadFile.mockImplementation(async (p: string) => {
+      if (p === "/project/foo.ts") return "content-from-project";
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    const results = await readFileContentsForReview(
+      PROJECT_PATH,
+      ["foo.ts"],
+      { worktreePath: WORKTREE_PATH }
+    );
+
+    // "foo.ts" は segments.length === 1 のため prefix除去候補は生成されず、
+    // worktreeルート直下 → projectPath の順で試行され、projectPath側で解決される
+    expect(results[0].content).toBe("content-from-project");
+  });
+});

--- a/packages/maid-agent-messenger/src/services/quality-service.ts
+++ b/packages/maid-agent-messenger/src/services/quality-service.ts
@@ -250,10 +250,86 @@ export interface FileContent {
 export interface FileReadOptions {
   maxLinesPerFile?: number;
   maxTotalLines?: number;
+  /**
+   * worktree運用時、実装ファイルが実際に存在するworktreeルートの絶対パス。
+   * 報告書の変更ファイルパスにリポジトリ名prefixが含まれる場合（例:
+   * "codelodis/packages/foo.ts"）でも解決できるよう、prefix除去版も候補に含める。
+   */
+  worktreePath?: string;
 }
 
 const DEFAULT_MAX_LINES_PER_FILE = 300;
 const DEFAULT_MAX_TOTAL_LINES = 1500;
+
+/**
+ * ファイルパスの解決候補（絶対パス）を1件表す
+ */
+interface FilePathCandidate {
+  absolutePath: string;
+  base: string;
+}
+
+/**
+ * base配下（base自身を含む）にtargetが収まっているか判定する
+ */
+function isWithinBase(base: string, target: string): boolean {
+  return target === base || target.startsWith(base + path.sep);
+}
+
+/**
+ * 変更ファイルパスの解決候補を優先順位順に構築する
+ *
+ * 相対パスの場合、worktreePathが指定されていれば以下の順で候補を作る:
+ *   1. worktreeルート直下（filePathそのまま）
+ *   2. worktreeルート直下（先頭セグメント＝リポジトリ名prefixを除去）
+ *   3. projectPath基準（従来通り）
+ *
+ * 絶対パスの場合はprojectPath配下かどうかのみを検証する（従来通り）。
+ * 各候補はbase外へ逸脱していないことを個別に検証済みのもののみ返す
+ * （パストラバーサル防止）。
+ */
+function buildFilePathCandidates(
+  projectPath: string,
+  worktreePath: string | undefined,
+  filePath: string
+): FilePathCandidate[] {
+  const normalizedProjectPath = path.normalize(projectPath);
+
+  if (path.isAbsolute(filePath)) {
+    const absolutePath = path.normalize(filePath);
+    return isWithinBase(normalizedProjectPath, absolutePath)
+      ? [{ absolutePath, base: normalizedProjectPath }]
+      : [];
+  }
+
+  const candidates: FilePathCandidate[] = [];
+
+  if (worktreePath) {
+    const normalizedWorktreePath = path.normalize(worktreePath);
+
+    const direct = path.normalize(path.join(normalizedWorktreePath, filePath));
+    if (isWithinBase(normalizedWorktreePath, direct)) {
+      candidates.push({ absolutePath: direct, base: normalizedWorktreePath });
+    }
+
+    const segments = filePath.split("/");
+    if (segments.length > 1) {
+      const stripped = path.normalize(
+        path.join(normalizedWorktreePath, segments.slice(1).join("/"))
+      );
+      if (isWithinBase(normalizedWorktreePath, stripped)) {
+        candidates.push({ absolutePath: stripped, base: normalizedWorktreePath });
+      }
+    }
+  }
+
+  const fromProject = path.normalize(path.join(normalizedProjectPath, filePath));
+  if (isWithinBase(normalizedProjectPath, fromProject)) {
+    candidates.push({ absolutePath: fromProject, base: normalizedProjectPath });
+  }
+
+  return candidates;
+}
 
 /**
  * 報告書から変更ファイルパスを抽出
@@ -310,6 +386,7 @@ export async function readFileContentsForReview(
 ): Promise<FileContent[]> {
   const maxLinesPerFile = options.maxLinesPerFile || DEFAULT_MAX_LINES_PER_FILE;
   const maxTotalLines = options.maxTotalLines || DEFAULT_MAX_TOTAL_LINES;
+  const worktreePath = options.worktreePath;
 
   const results: FileContent[] = [];
   let totalLines = 0;
@@ -326,16 +403,10 @@ export async function readFileContentsForReview(
       continue;
     }
 
-    // ファイルパスを解決（相対パス → 絶対パス）
-    // パストラバーサル防止: プロジェクトパス外へのアクセスを拒否
-    const normalizedProjectPath = path.normalize(projectPath);
-    const absolutePath = path.isAbsolute(filePath)
-      ? path.normalize(filePath)
-      : path.normalize(path.join(projectPath, filePath));
+    // ファイルパスの解決候補を構築（worktree優先 → projectPathの順。パストラバーサル防止込み）
+    const candidates = buildFilePathCandidates(projectPath, worktreePath, filePath);
 
-    // プロジェクトパス外へのアクセスをチェック
-    if (!absolutePath.startsWith(normalizedProjectPath + path.sep) &&
-        absolutePath !== normalizedProjectPath) {
+    if (candidates.length === 0) {
       results.push({
         path: filePath,
         content: "",
@@ -346,52 +417,63 @@ export async function readFileContentsForReview(
       continue;
     }
 
-    try {
-      const content = await fs.readFile(absolutePath, "utf-8");
-      const lines = content.split("\n");
-      const lineCount = lines.length;
-
-      // 残り許容行数を計算
-      const remainingLines = maxTotalLines - totalLines;
-      const allowedLines = Math.min(maxLinesPerFile, remainingLines);
-
-      if (lineCount <= allowedLines) {
-        // 全文を含める
-        results.push({
-          path: filePath,
-          content: content,
-          truncated: false,
-          lineCount,
-        });
-        totalLines += lineCount;
-      } else {
-        // 先頭と末尾を含め、中央を省略
-        const headLines = Math.floor(allowedLines / 2);
-        const tailLines = allowedLines - headLines;
-
-        const head = lines.slice(0, headLines).join("\n");
-        const tail = lines.slice(-tailLines).join("\n");
-        const omittedCount = lineCount - headLines - tailLines;
-
-        const truncatedContent = `${head}\n\n... (${omittedCount}行省略) ...\n\n${tail}`;
-
-        results.push({
-          path: filePath,
-          content: truncatedContent,
-          truncated: true,
-          lineCount,
-        });
-        totalLines += allowedLines;
+    // 候補を順に試行し、最初に読み込めたものを採用する
+    let content: string | undefined;
+    let lastError: unknown;
+    for (const candidate of candidates) {
+      try {
+        content = await fs.readFile(candidate.absolutePath, "utf-8");
+        break;
+      } catch (err) {
+        lastError = err;
       }
-    } catch (err) {
-      // ファイル読み込みエラー
+    }
+
+    if (content === undefined) {
       results.push({
         path: filePath,
         content: "",
         truncated: false,
         lineCount: 0,
-        error: err instanceof Error ? err.message : "Unknown error",
+        error: lastError instanceof Error ? lastError.message : "Unknown error",
       });
+      continue;
+    }
+
+    const lines = content.split("\n");
+    const lineCount = lines.length;
+
+    // 残り許容行数を計算
+    const remainingLines = maxTotalLines - totalLines;
+    const allowedLines = Math.min(maxLinesPerFile, remainingLines);
+
+    if (lineCount <= allowedLines) {
+      // 全文を含める
+      results.push({
+        path: filePath,
+        content: content,
+        truncated: false,
+        lineCount,
+      });
+      totalLines += lineCount;
+    } else {
+      // 先頭と末尾を含め、中央を省略
+      const headLines = Math.floor(allowedLines / 2);
+      const tailLines = allowedLines - headLines;
+
+      const head = lines.slice(0, headLines).join("\n");
+      const tail = lines.slice(-tailLines).join("\n");
+      const omittedCount = lineCount - headLines - tailLines;
+
+      const truncatedContent = `${head}\n\n... (${omittedCount}行省略) ...\n\n${tail}`;
+
+      results.push({
+        path: filePath,
+        content: truncatedContent,
+        truncated: true,
+        lineCount,
+      });
+      totalLines += allowedLines;
     }
   }
 

--- a/project-templates/system/bin/quality-check-llm.sh
+++ b/project-templates/system/bin/quality-check-llm.sh
@@ -2,12 +2,16 @@
 # =============================================================================
 # quality-check-llm.sh - LLMによる報告書品質チェック
 #
-# 使用法: quality-check-llm.sh <report_file> <task_type> [project_root]
+# 使用法: quality-check-llm.sh <report_file> <task_type> [project_root] [worktree_root]
 #
 # 引数:
-#   report_file  - チェック対象の報告書ファイルパス
-#   task_type    - タスク種別 (investigation/work/step/task)
-#   project_root - プロジェクトルート（省略時: CLAUDE_PROJECT_DIR または pwd）
+#   report_file   - チェック対象の報告書ファイルパス
+#   task_type     - タスク種別 (investigation/work/step/task)
+#   project_root  - プロジェクトルート（省略時: CLAUDE_PROJECT_DIR または pwd）
+#   worktree_root - worktree運用時、実装ファイルが実際に存在するworktreeルートの
+#                   絶対パス（省略可。呼び出し元(maidctl)がgit worktreeを検出した
+#                   場合に渡す。成果物評価（変更ファイル内容の読み込み）のみに使用され、
+#                   settings.yaml等の設定読み込みは引き続きproject_root基準）
 #
 # 終了コード:
 #   0 - チェック合格または警告のみ
@@ -23,6 +27,7 @@ set -euo pipefail
 REPORT_FILE="${1:-}"
 TASK_TYPE="${2:-step}"
 PROJECT_ROOT="${3:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
+WORKTREE_ROOT="${4:-}"
 
 # パス定義
 CONFIG_FILE="$PROJECT_ROOT/.maid-agent/system/config/settings.yaml"
@@ -143,6 +148,7 @@ run_llm_check() {
 
   debug_log "TaskId: $task_id_val"
   debug_log "Model: $LLM_MODEL"
+  debug_log "WorktreeRoot: $WORKTREE_ROOT"
 
   # maid-agent-messenger API経由でLLMチェック実行
   local server_url="${MAID_SERVER_URL:-http://localhost:3100}"
@@ -159,7 +165,8 @@ run_llm_check() {
       --arg aid "$agent_id" \
       --arg mdl "$LLM_MODEL" \
       --argjson to "$timeout_ms" \
-      '{taskId:$tid,taskType:$tt,reportContent:$rc,agentId:$aid,options:{model:$mdl,timeout:$to}}')
+      --arg wtp "$WORKTREE_ROOT" \
+      '{taskId:$tid,taskType:$tt,reportContent:$rc,agentId:$aid,options:{model:$mdl,timeout:$to}} + (if $wtp == "" then {} else {worktreePath:$wtp} end)')
   else
     # jqがない場合は簡易的なJSON（reportContentのエスケープが不完全な可能性あり）
     echo "警告: jqがインストールされていません。正確なJSON構築ができない可能性があります。" >&2


### PR DESCRIPTION
## Summary
- `maidctl set my-status completed` 実行時のLLM品質チェックが、worktree運用時にworktreeではなくメインリポジトリ（未変更のdevブランチ）を参照して成果物評価を行い、「未実装」「report矛盾」の誤ったcritical判定を出していた問題を修正（task-1641改善提案・task-1640-1報告が起点）
- `maidctl`: `quality_check()` 実行時、カレントディレクトリがgitのlinked worktreeかを検出し、検出時のみworktreeルートを`quality-check-llm.sh`へ渡す
- `quality-check-llm.sh`: worktree_root引数を受け取り、APIペイロードに`worktreePath`として含める（設定読み込みは引き続きproject_root基準）
- `quality-service.ts`: `readFileContentsForReview`に`worktreePath`オプションを追加。相対パスの変更ファイルは (1) worktreeルート直下 (2) worktreeルート直下（リポジトリ名prefix除去） (3) projectPath基準（従来通り）の順で解決を試みる

## Test plan
- [x] TDD: `quality-service-worktree.test.ts`（7ケース）を先に作成し失敗確認後、実装して全通過
- [x] `maidctl-detect-linked-worktree.test.sh`（実gitリポジトリ/linked worktreeに対する検証・3ケース）新規作成・全通過
- [x] 既存bashテスト（maid-worktree-add / checkpoint-pass / assign-task-warning / task-list-action-required）全通過（回帰なし）
- [x] `npm run build`（maid-agent-messenger）成功
- [x] `packages/maid-agent-messenger` 全テストスイート実行: 517 tests / 42 suites 全passed（回帰なし）
- [x] 実際の不具合報告（task-1640-1）と同じシナリオ（メイン=未変更content、worktree=実装済みcontent）を再現するNode検証スクリプトで、worktreePath指定時にworktree側の内容が正しく参照されることを実機確認

## 補足（デプロイについて）
本PRはリポジトリ内のソース（`global-templates/`配下の再ビルド済みdist含む）の修正です。実運用環境（`.maid-agent/system/bin/quality-check-llm.sh`・`~/.maid-agent/bin/maidctl`）への反映は、マージ後に既存の更新手順（Init/Update）で別途同期が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)