### PR TITLE
feat(task-1688-2): 判断待ちタスクの一時退避（案B）データモデル拡張

### DIFF
--- a/global-templates/bin/maidctl
+++ b/global-templates/bin/maidctl
@@ -413,7 +413,10 @@ format_my_task() {
     "Description: \(.description // "-")",
     "Target Path: \(.target_path // "-")",
     "Assigned At: \(.assigned_at // "-")",
-    "Started At: \(.started_at // "-")"
+    "Started At: \(.started_at // "-")",
+    (if (.parked_tasks // []) | length > 0 then
+      (.parked_tasks[] | "パーク中: \(.task_id)（\(.title // "-")）")
+    else empty end)
   '
 }
 
@@ -991,6 +994,88 @@ cmd_task_assign() {
       [ -n "$warning" ] && echo "⚠️  $warning" >&2
     fi
   fi
+}
+
+# =============================================================================
+# resume-parked-task サブコマンド（task-1688-2・案B）
+# =============================================================================
+
+cmd_resume_parked_task() {
+  local task_id=""
+  local agent_id=""
+  local json_output=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --agent|-a) agent_id="$2"; shift 2 ;;
+      --json) json_output=true; shift ;;
+      --help|-h)
+        echo "使用法: maidctl resume-parked-task <task-id> --agent AGENT_ID [オプション]"
+        echo ""
+        echo "パーク中タスクを再開する（チーフ専用の明示的操作。自動昇格はしない）。"
+        echo ""
+        echo "オプション:"
+        echo "  --agent, -a AGENT_ID  対象メイド（必須）"
+        echo "  --json                JSON出力"
+        echo ""
+        echo "有効なエージェント: $VALID_AGENTS"
+        return 0
+        ;;
+      -*)
+        echo "エラー: 不明なオプション: $1" >&2
+        echo "  -h/--help でオプション一覧を確認できます" >&2
+        exit $EXIT_INVALID_ARGS
+        ;;
+      *)
+        if [ -z "$task_id" ]; then
+          task_id="$1"
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  if [ -z "$task_id" ]; then
+    echo "エラー: タスクIDを指定してください" >&2
+    exit $EXIT_INVALID_ARGS
+  fi
+
+  if [ -z "$agent_id" ]; then
+    echo "エラー: 対象メイドを指定してください (--agent)" >&2
+    exit $EXIT_INVALID_ARGS
+  fi
+
+  # エージェントIDの検証
+  if ! echo "$VALID_AGENTS" | grep -qw "$agent_id"; then
+    echo "エラー: 無効なエージェント: $agent_id" >&2
+    echo "有効なエージェント: $VALID_AGENTS" >&2
+    exit $EXIT_INVALID_ARGS
+  fi
+
+  local escaped_task_id
+  escaped_task_id=$(json_escape "$task_id")
+  local data="{\"taskId\": \"$escaped_task_id\"}"
+
+  local result
+  result=$(api_request POST "/api/agents/${agent_id}/resume-parked-task" "$data")
+
+  if [ "$json_output" = true ]; then
+    echo "$result"
+    return
+  fi
+
+  if check_jq; then
+    local success
+    success=$(echo "$result" | jq -r '.success // false' 2>/dev/null)
+    if [ "$success" != "true" ]; then
+      local error_msg
+      error_msg=$(echo "$result" | jq -r '.error // "不明なエラー"' 2>/dev/null)
+      echo "エラー: $error_msg" >&2
+      exit $EXIT_INVALID_ARGS
+    fi
+  fi
+
+  echo "タスク #$task_id を $agent_id で再開しました"
 }
 
 # =============================================================================
@@ -1818,6 +1903,8 @@ maidctl - Maid Agent CLI Tool v${VERSION}
 
   notify <target> "msg"  通知を送信
 
+  resume-parked-task <id> --agent AGENT_ID  パーク中タスクを再開（チーフ用・task-1688-2）
+
 コマンド（旧形式・後方互換）:
   task list/get/create/update/assign
   my-task / my-status
@@ -2442,6 +2529,7 @@ main() {
       ;;
     my-task) shift; cmd_my_task "$@" ;;
     my-status) shift; cmd_my_status "$@" ;;
+    resume-parked-task) shift; cmd_resume_parked_task "$@" ;;
     team)
       shift
       case "${1:-}" in

--- a/global-templates/bin/test/maidctl-format-my-task-parked.test.sh
+++ b/global-templates/bin/test/maidctl-format-my-task-parked.test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# maidctl format_my_task パーク中タスク表示テスト（task-1688-2 案B）
+#
+# 背景: get my-task の非JSON出力に、parked_tasks（判断待ちで一時退避されたタスク）を
+# 表示する。サーバー側のレスポンス形状は
+# packages/maid-agent-messenger/src/__tests__/services/get-my-task.test.ts で別途検証済み。
+# 本テストは CLI 側の表示ロジックのみを検証する。
+#
+# 完了条件:
+#   - parked_tasks がある場合 → パーク中タスクのIDを画面表示する
+#   - parked_tasks がない場合 → 追加表示なし（既存出力を壊さない）
+#
+# 実行: bash global-templates/bin/test/maidctl-format-my-task-parked.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAIDCTL_SOURCE="${SCRIPT_DIR}/../maidctl"
+
+pass=0
+fail=0
+
+FORMAT_FUNC_SRC="$(sed -n '/^format_my_task() {/,/^}/p' "${MAIDCTL_SOURCE}")"
+CHECK_JQ_FUNC_SRC="$(sed -n '/^check_jq() {/,/^}/p' "${MAIDCTL_SOURCE}")"
+
+run_format() {
+  (
+    eval "${CHECK_JQ_FUNC_SRC}"
+    eval "${FORMAT_FUNC_SRC}"
+    format_my_task "$1"
+  )
+}
+
+echo "=== maidctl format_my_task parked_tasks display tests ==="
+echo ""
+
+# -----------------------------------------------------------------------
+# parked_tasksがある場合、パーク中タスクIDを表示する
+# -----------------------------------------------------------------------
+output="$(run_format '{"task_id":"task-200","status":"assigned","description":"新タスク","parked_tasks":[{"task_id":"task-199","title":"判断待ちタスク","substatus":"checkpoint","parked_at":"2026-08-07T09:00:00Z"}]}' 2>&1)"
+if echo "${output}" | grep -q "task-199"; then
+  echo "PASS: parked_tasksありでパーク中タスクIDを表示した"
+  pass=$((pass + 1))
+else
+  echo "FAIL: parked_tasksありでもパーク中タスクIDが表示されなかった"
+  echo "${output}" | sed 's/^/    /'
+  fail=$((fail + 1))
+fi
+
+# -----------------------------------------------------------------------
+# parked_tasksがない場合、既存出力を壊さない（回帰確認）
+# -----------------------------------------------------------------------
+output="$(run_format '{"task_id":"task-100","status":"working","description":"テストタスク"}' 2>&1)"
+if echo "${output}" | grep -q "Task ID: task-100"; then
+  echo "PASS: parked_tasksなしでも既存出力は維持される"
+  pass=$((pass + 1))
+else
+  echo "FAIL: 既存出力が壊れた"
+  echo "${output}" | sed 's/^/    /'
+  fail=$((fail + 1))
+fi
+if echo "${output}" | grep -qi "パーク"; then
+  echo "FAIL: parked_tasksなしなのにパーク表示が出た"
+  fail=$((fail + 1))
+else
+  echo "PASS: parked_tasksなしでパーク表示は出ない"
+  pass=$((pass + 1))
+fi
+
+echo ""
+echo "Results: ${pass} passed, ${fail} failed"
+[[ ${fail} -eq 0 ]]

--- a/global-templates/bin/test/maidctl-resume-parked-task.test.sh
+++ b/global-templates/bin/test/maidctl-resume-parked-task.test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# maidctl resume-parked-task テスト（task-1688-2 案B）
+#
+# 背景: パーク中タスクの再開はチーフ専用の明示的操作。優先順位のブレを防止するため
+# 自動昇格は行わず、本コマンドを呼んだときのみ再開が発生する（サーバー側ロジックは
+# packages/maid-agent-messenger/src/__tests__/services/resume-parked-task.test.ts で
+# 別途検証済み）。本テストは CLI 側の引数処理・レスポンスハンドリングのみを検証する。
+#
+# 完了条件:
+#   - 正常系: TASK_ID 指定 + --agent 指定 → 成功メッセージを表示
+#   - 異常系: サービスがエラーを返す → エラーメッセージを表示し非ゼロ終了
+#   - 異常系: TASK_ID 未指定 → エラー終了
+#   - 異常系: --agent 未指定 → エラー終了
+#
+# 実行: bash global-templates/bin/test/maidctl-resume-parked-task.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAIDCTL_SOURCE="${SCRIPT_DIR}/../maidctl"
+
+pass=0
+fail=0
+
+CMD_FUNC_SRC="$(sed -n '/^cmd_resume_parked_task() {/,/^}/p' "${MAIDCTL_SOURCE}")"
+if [[ -z "${CMD_FUNC_SRC}" ]]; then
+  echo "FAIL: cmd_resume_parked_task 関数が ${MAIDCTL_SOURCE} に見つかりません"
+  exit 1
+fi
+
+CHECK_JQ_FUNC_SRC="$(sed -n '/^check_jq() {/,/^}/p' "${MAIDCTL_SOURCE}")"
+
+run_cmd() {
+  # $1 = api_request が返す JSON レスポンス（スタブ）
+  # $2以降 = cmd_resume_parked_task への引数
+  local stub_response="$1"; shift
+  (
+    EXIT_INVALID_ARGS=5
+    VALID_AGENTS="emma sophia lily rose alice may flora luna"
+
+    api_request() {
+      echo "${STUB_RESPONSE}"
+    }
+
+    STUB_RESPONSE="${stub_response}"
+
+    eval "${CHECK_JQ_FUNC_SRC}"
+    eval "${CMD_FUNC_SRC}"
+    cmd_resume_parked_task "$@"
+  )
+}
+
+echo "=== maidctl resume-parked-task tests ==="
+echo ""
+
+# -----------------------------------------------------------------------
+# 正常系: 成功レスポンス → 再開したタスクIDを画面表示
+# -----------------------------------------------------------------------
+output="$(run_cmd '{"success":true,"agent_id":"emma","task_id":"task-199"}' task-199 --agent emma 2>&1)"
+if echo "${output}" | grep -q "task-199"; then
+  echo "PASS: 正常系 → 再開したタスクIDを表示した"
+  pass=$((pass + 1))
+else
+  echo "FAIL: 正常系レスポンスでもタスクIDが表示されなかった"
+  echo "${output}" | sed 's/^/    /'
+  fail=$((fail + 1))
+fi
+
+# -----------------------------------------------------------------------
+# 異常系: サービスがエラーを返す → エラーメッセージを表示し非ゼロ終了
+# -----------------------------------------------------------------------
+if output="$(run_cmd '{"success":false,"error":"見つかりません"}' task-999 --agent emma 2>&1)"; then
+  echo "FAIL: サービスエラー時にゼロ終了してしまった"
+  echo "${output}" | sed 's/^/    /'
+  fail=$((fail + 1))
+else
+  if echo "${output}" | grep -q "見つかりません"; then
+    echo "PASS: サービスエラー時にエラーメッセージを表示し非ゼロ終了した"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: サービスエラー時にエラーメッセージが表示されなかった"
+    echo "${output}" | sed 's/^/    /'
+    fail=$((fail + 1))
+  fi
+fi
+
+# -----------------------------------------------------------------------
+# 異常系: TASK_ID未指定 → エラー終了
+# -----------------------------------------------------------------------
+if output="$(run_cmd '{}' --agent emma 2>&1)"; then
+  echo "FAIL: TASK_ID未指定でもゼロ終了してしまった"
+  fail=$((fail + 1))
+else
+  echo "PASS: TASK_ID未指定でエラー終了した"
+  pass=$((pass + 1))
+fi
+
+# -----------------------------------------------------------------------
+# 異常系: --agent未指定 → エラー終了
+# -----------------------------------------------------------------------
+if output="$(run_cmd '{}' task-199 2>&1)"; then
+  echo "FAIL: --agent未指定でもゼロ終了してしまった"
+  fail=$((fail + 1))
+else
+  echo "PASS: --agent未指定でエラー終了した"
+  pass=$((pass + 1))
+fi
+
+echo ""
+echo "Results: ${pass} passed, ${fail} failed"
+[[ ${fail} -eq 0 ]]

--- a/global-templates/maid-agent-messenger/dist/routes/cli-api-routes.js
+++ b/global-templates/maid-agent-messenger/dist/routes/cli-api-routes.js
@@ -11,7 +11,7 @@
  */
 import path from "path";
 import { Router } from "express";
-import { executeCreateTask, executeAssignTask, executeGetMyTask, executeUpdateStatus, executeGetTeamStatus, } from "../services/index.js";
+import { executeCreateTask, executeAssignTask, executeGetMyTask, executeUpdateStatus, executeGetTeamStatus, executeResumeParkedTask, } from "../services/index.js";
 import { getProjectPathFromRequest } from "../middleware/project-path.js";
 import { MAID_IDS } from "../types/index.js";
 import { VALIDATION } from "../utils/constants.js";
@@ -186,6 +186,51 @@ export function createCliApiRoutes(deps = {}) {
         catch (error) {
             const message = error instanceof Error ? error.message : "Unknown error";
             res.status(500).json({ error: "Task retrieval failed", details: message });
+        }
+    });
+    // =============================================================================
+    // POST /api/agents/:id/resume-parked-task - パーク中タスク再開（task-1688-2・案B）
+    // =============================================================================
+    router.post("/api/agents/:id/resume-parked-task", async (req, res) => {
+        try {
+            const projectPath = getProjectPathFromRequest(req);
+            const agentId = req.params.id;
+            const { taskId } = req.body;
+            if (!MAID_IDS.includes(agentId)) {
+                res.status(400).json({
+                    error: "Invalid agentId",
+                    validAgents: MAID_IDS,
+                });
+                return;
+            }
+            if (!taskId || typeof taskId !== "string") {
+                res.status(400).json({ error: "taskId is required" });
+                return;
+            }
+            const paths = buildInternalPaths(projectPath);
+            const result = await executeResumeParkedTask({
+                queueMaidPath: paths.queueMaidPath,
+                projectPath,
+                agentId,
+                taskId,
+            });
+            if (!result.success) {
+                res.status(400).json({
+                    error: result.error || "Resume failed",
+                    agentId,
+                    taskId,
+                });
+                return;
+            }
+            res.json({
+                success: true,
+                agent_id: result.agent_id,
+                task_id: result.task_id,
+            });
+        }
+        catch (error) {
+            const message = error instanceof Error ? error.message : "Unknown error";
+            res.status(500).json({ error: "Resume parked task failed", details: message });
         }
     });
     // =============================================================================

--- a/global-templates/maid-agent-messenger/dist/services/assign-task.js
+++ b/global-templates/maid-agent-messenger/dist/services/assign-task.js
@@ -6,7 +6,7 @@
  * executeUpdateTask に全処理を委譲する。
  */
 import path from "path";
-import { readYamlFile } from "../utils/yaml-helper.js";
+import { readYamlFile, writeYamlFile, getTimestamp } from "../utils/yaml-helper.js";
 import { withFileLock } from "../utils/file-lock.js";
 import { executeUpdateTask, executeGetTask, executeGetTaskChildren } from "./task-manager.js";
 import { normalizeTaskId } from "../utils/task-id.js";
@@ -30,6 +30,50 @@ export async function executeAssignTask(params) {
             error: `${targetAgent} は現在作業中です（${maidTask.task_id}）`,
         };
     }
+    // task-1688-2（案B）: blocked状態（判断待ち）のメイドへは、現在のタスクをパークしてから
+    // 新タスクの割当へ進む（パーク・オン・アサイン）。parked_tasksは最大1件（優先順位のブレ防止）。
+    if (maidTask.status === "blocked") {
+        const guardParked = maidTask.parked_tasks ?? [];
+        if (guardParked.length > 0) {
+            return {
+                success: false,
+                assigned_to: targetAgent,
+                task_id: maidTask.task_id || "",
+                error: `${targetAgent} は既にパーク中タスク（${guardParked[0].task_id}）を保持しています。先にresolveするか、別メイドへの配分を検討してください。`,
+            };
+        }
+        // メイのレビューSHOULD(a): ガード確認時点のスナップショット（maidTask）は書き込みに使わず、
+        // 新しいロックの中で再読込した最新状態を元にパーク判定・書き込みを行う（TOCTOU対策）。
+        let parkConflict = null;
+        await withFileLock(filePath, async () => {
+            const latest = await readYamlFile(filePath);
+            const latestParked = latest.parked_tasks ?? [];
+            if (latestParked.length > 0) {
+                parkConflict = latestParked[0].task_id;
+                return;
+            }
+            if (!latest.task_id)
+                return;
+            const parkedEntry = {
+                task_id: latest.task_id,
+                title: latest.title,
+                substatus: latest.substatus,
+                parked_at: getTimestamp(),
+            };
+            await writeYamlFile(filePath, {
+                ...latest,
+                parked_tasks: [parkedEntry],
+            });
+        });
+        if (parkConflict) {
+            return {
+                success: false,
+                assigned_to: targetAgent,
+                task_id: maidTask.task_id || "",
+                error: `${targetAgent} は既にパーク中タスク（${parkConflict}）を保持しています。先にresolveするか、別メイドへの配分を検討してください。`,
+            };
+        }
+    }
     // executeUpdateTask に全処理を委譲（maid yaml ロック解放済み）
     const projectPath = path.resolve(queueMaidPath, "..", "..", "..", "..");
     const taskIdNormalized = normalizeTaskId(taskId);
@@ -52,7 +96,7 @@ export async function executeAssignTask(params) {
     // 既存 assignees チェック
     if (taskResult.task && taskResult.task.assignees && taskResult.task.assignees.length > 0) {
         if (!force) {
-            const existingAgents = taskResult.task.assignees.map(a => a.agentId).join(", ");
+            const existingAgents = taskResult.task.assignees.map((a) => a.agentId).join(", ");
             return {
                 success: false,
                 assigned_to: targetAgent,

--- a/global-templates/maid-agent-messenger/dist/services/get-my-task.d.ts
+++ b/global-templates/maid-agent-messenger/dist/services/get-my-task.d.ts
@@ -3,7 +3,7 @@
  *
  * 自分に割り当てられたタスク情報を取得する処理
  */
-import type { GetMyTaskOutput } from "../types/index.js";
+import type { GetMyTaskOutput, ParkedTask } from "../types/index.js";
 export interface GetMyTaskParams {
     queueMaidPath: string;
     agentId: string;
@@ -23,6 +23,7 @@ export interface ParentTaskInfo {
 export interface GetMyTaskResult extends GetMyTaskOutput {
     message?: string;
     parent_chain?: ParentTaskInfo[];
+    parked_tasks?: ParkedTask[];
 }
 /**
  * タスク情報を取得

--- a/global-templates/maid-agent-messenger/dist/services/get-my-task.js
+++ b/global-templates/maid-agent-messenger/dist/services/get-my-task.js
@@ -97,5 +97,7 @@ export async function executeGetMyTask(params) {
         assigned_at: task.assigned_at || null,
         started_at: task.started_at || null,
         ...(parentChain && parentChain.length > 0 && { parent_chain: parentChain }),
+        // task-1688-2（案B）: パーク中タスク一覧（0件なら省略・既存レスポンス形状を維持）
+        ...(task.parked_tasks && task.parked_tasks.length > 0 && { parked_tasks: task.parked_tasks }),
     };
 }

--- a/global-templates/maid-agent-messenger/dist/services/index.d.ts
+++ b/global-templates/maid-agent-messenger/dist/services/index.d.ts
@@ -6,6 +6,7 @@
 export { executeGetMyTask, type GetMyTaskParams, type GetMyTaskResult } from "./get-my-task.js";
 export { executeUpdateStatus, type UpdateStatusParams } from "./update-status.js";
 export { executeAssignTask, type AssignTaskParams } from "./assign-task.js";
+export { executeResumeParkedTask, type ResumeParkedTaskParams, type ResumeParkedTaskOutput, } from "./resume-parked-task.js";
 export { executeGetTeamStatus, type GetTeamStatusParams } from "./get-team-status.js";
 export { executeCreateTask, executeGetTask, executeListTasks, executeUpdateTask, resolveBlockedTasks, checkGoalAutoClose, inferTaskType, convertStatus, generateDashboardData, type CreateTaskParams, type CreateTaskResult, type GetTaskParams, type GetTaskResult, type ListTasksParams, type ListTasksResult, type UpdateTaskParams, type UpdateTaskResult, type Task, type TaskSummary, type TaskStatus, type Assignee, type TasksData, migrate, checkMigrationStatus, type TaskType, type TaskMainStatus, type TaskSubstatus, type TaskSize, type ReviewStatus, type RetentionLevel, type TaskArtifact, type DependencyResolutionResult, type MigrationResult, type DashboardData, type TaskData, type WorkData, type StepData, type GoalData, type PhaseData, type ActionData, type ReviewTaskData, type ArtifactData, type StatsData, } from "./task-manager.js";
 export { executeGetReport, type GetReportParams, type GetReportResult, type ReportEntry, } from "./get-report.js";

--- a/global-templates/maid-agent-messenger/dist/services/index.js
+++ b/global-templates/maid-agent-messenger/dist/services/index.js
@@ -6,6 +6,7 @@
 export { executeGetMyTask } from "./get-my-task.js";
 export { executeUpdateStatus } from "./update-status.js";
 export { executeAssignTask } from "./assign-task.js";
+export { executeResumeParkedTask, } from "./resume-parked-task.js";
 export { executeGetTeamStatus } from "./get-team-status.js";
 // タスク管理サービス（V2.1）
 export { executeCreateTask, executeGetTask, executeListTasks, executeUpdateTask, 

--- a/global-templates/maid-agent-messenger/dist/services/resume-parked-task.d.ts
+++ b/global-templates/maid-agent-messenger/dist/services/resume-parked-task.d.ts
@@ -1,0 +1,26 @@
+/**
+ * resume_parked_task ビジネスロジック（task-1688-2・案B）
+ *
+ * パーク中タスクを maid yaml のアクティブスロットへ再開（昇格）する。
+ * tasks.yaml 側のstatus遷移（blocked→working）は対象外——それは引き続き
+ * メイド自身が `maidctl set my-status working` で行う（update-status.ts は無改修）。
+ * 本関数は「メイドのアクティブスロットがどのタスクを指すか」というローカルな
+ * スワップ・昇格のみを担う。
+ *
+ * 優先順位のブレ防止: 自動昇格は一切行わない。チーフが明示的にこの関数（コマンド）を
+ * 呼んだときのみ再開が発生する。
+ */
+export interface ResumeParkedTaskParams {
+    queueMaidPath: string;
+    projectPath: string;
+    agentId: string;
+    /** 再開対象のパーク中タスクID */
+    taskId: string;
+}
+export interface ResumeParkedTaskOutput {
+    success: boolean;
+    agent_id: string;
+    task_id: string;
+    error?: string;
+}
+export declare function executeResumeParkedTask(params: ResumeParkedTaskParams): Promise<ResumeParkedTaskOutput>;

--- a/global-templates/maid-agent-messenger/dist/services/resume-parked-task.js
+++ b/global-templates/maid-agent-messenger/dist/services/resume-parked-task.js
@@ -12,7 +12,7 @@
  */
 import path from "path";
 import { toMaidTaskStatus } from "../types/index.js";
-import { readYamlFile, writeYamlFile } from "../utils/yaml-helper.js";
+import { readYamlFile, writeYamlFile, getTimestamp } from "../utils/yaml-helper.js";
 import { withFileLock } from "../utils/file-lock.js";
 import { executeGetTask } from "./task-manager.js";
 import { normalizeTaskId } from "../utils/task-id.js";
@@ -74,7 +74,7 @@ export async function executeResumeParkedTask(params) {
                 task_id: maidYaml.task_id,
                 title: maidYaml.title,
                 substatus: maidYaml.substatus,
-                parked_at: new Date().toISOString(),
+                parked_at: getTimestamp(),
             });
         }
         const updated = {
@@ -85,7 +85,9 @@ export async function executeResumeParkedTask(params) {
             target_path: freshTask.targetPath ?? null,
             status: toMaidTaskStatus(freshTask.status),
             substatus: freshTask.substatus,
-            assigned_at: freshTask.assignedAt,
+            // 計画書§3-6手順3: assigned_atのみ「再開」を表す現在時刻で更新する。
+            // started_at/completed_at等はtasks.yaml側の値をそのまま据え置き、既存タスクの経過を保持する。
+            assigned_at: getTimestamp(),
             started_at: freshTask.startedAt,
             completed_at: freshTask.completedAt,
             completion_summary: freshTask.summary,

--- a/global-templates/maid-agent-messenger/dist/services/resume-parked-task.js
+++ b/global-templates/maid-agent-messenger/dist/services/resume-parked-task.js
@@ -1,0 +1,102 @@
+/**
+ * resume_parked_task ビジネスロジック（task-1688-2・案B）
+ *
+ * パーク中タスクを maid yaml のアクティブスロットへ再開（昇格）する。
+ * tasks.yaml 側のstatus遷移（blocked→working）は対象外——それは引き続き
+ * メイド自身が `maidctl set my-status working` で行う（update-status.ts は無改修）。
+ * 本関数は「メイドのアクティブスロットがどのタスクを指すか」というローカルな
+ * スワップ・昇格のみを担う。
+ *
+ * 優先順位のブレ防止: 自動昇格は一切行わない。チーフが明示的にこの関数（コマンド）を
+ * 呼んだときのみ再開が発生する。
+ */
+import path from "path";
+import { toMaidTaskStatus } from "../types/index.js";
+import { readYamlFile, writeYamlFile } from "../utils/yaml-helper.js";
+import { withFileLock } from "../utils/file-lock.js";
+import { executeGetTask } from "./task-manager.js";
+import { normalizeTaskId } from "../utils/task-id.js";
+/**
+ * executeGetTask は summaryOnly 未指定時（本モジュールの呼び出し方）は必ず
+ * 完全な Task を返すが、戻り値の静的型は Task | TaskSummary の合併型のまま。
+ * TaskSummary には無い description で判定して狭める。
+ */
+function isFullTask(task) {
+    return "description" in task;
+}
+export async function executeResumeParkedTask(params) {
+    const { queueMaidPath, projectPath, agentId, taskId } = params;
+    const filePath = path.join(queueMaidPath, `${agentId}.yaml`);
+    const taskIdNormalized = normalizeTaskId(taskId);
+    const fullTaskId = `task-${taskIdNormalized}`;
+    let output = null;
+    await withFileLock(filePath, async () => {
+        const maidYaml = await readYamlFile(filePath);
+        const parkedTasks = maidYaml.parked_tasks ?? [];
+        const parkedIndex = parkedTasks.findIndex((p) => p.task_id === fullTaskId);
+        if (parkedIndex === -1) {
+            output = {
+                success: false,
+                agent_id: agentId,
+                task_id: fullTaskId,
+                error: `${agentId} のパーク中タスクに ${fullTaskId} が見つかりません。`,
+            };
+            return;
+        }
+        // アクティブタスクが進行中（working）の場合は再開を拒否する（安全側。強制中断はしない）
+        if (maidYaml.status === "working") {
+            output = {
+                success: false,
+                agent_id: agentId,
+                task_id: fullTaskId,
+                error: `${agentId} は現在 ${maidYaml.task_id} で作業中です。完了を待ってから再開してください。`,
+            };
+            return;
+        }
+        // 再開対象タスクの最新情報を tasks.yaml から取得する（title/description/target_path等の
+        // 鮮度を保証するため、パーク時点のスナップショット=ParkedTaskではなく都度再取得する）
+        const taskResult = await executeGetTask(projectPath, { taskId: taskIdNormalized });
+        if (!taskResult.task || !isFullTask(taskResult.task)) {
+            output = {
+                success: false,
+                agent_id: agentId,
+                task_id: fullTaskId,
+                error: `タスク #${fullTaskId} が tasks.yaml に見つかりません。`,
+            };
+            return;
+        }
+        const freshTask = taskResult.task;
+        const nextParkedTasks = parkedTasks.filter((_, i) => i !== parkedIndex);
+        // アクティブタスクが blocked の場合のみ、現在のアクティブタスクをパークへ退避する
+        // （idle=task_id無し／completed=既に完了済み、のいずれもスワップ不要でそのまま昇格）
+        if (maidYaml.status === "blocked" && maidYaml.task_id) {
+            nextParkedTasks.push({
+                task_id: maidYaml.task_id,
+                title: maidYaml.title,
+                substatus: maidYaml.substatus,
+                parked_at: new Date().toISOString(),
+            });
+        }
+        const updated = {
+            ...maidYaml,
+            task_id: fullTaskId,
+            title: freshTask.title,
+            description: freshTask.description,
+            target_path: freshTask.targetPath ?? null,
+            status: toMaidTaskStatus(freshTask.status),
+            substatus: freshTask.substatus,
+            assigned_at: freshTask.assignedAt,
+            started_at: freshTask.startedAt,
+            completed_at: freshTask.completedAt,
+            completion_summary: freshTask.summary,
+            parked_tasks: nextParkedTasks,
+        };
+        await writeYamlFile(filePath, updated);
+        output = {
+            success: true,
+            agent_id: agentId,
+            task_id: fullTaskId,
+        };
+    });
+    return output;
+}

--- a/global-templates/maid-agent-messenger/dist/services/task-side-effects.js
+++ b/global-templates/maid-agent-messenger/dist/services/task-side-effects.js
@@ -13,6 +13,7 @@ import * as fs from "fs/promises";
 import { readYamlFile, writeYamlFile, fileExists, copyFile, writeTextFile, sanitizeDescription, } from "../utils/yaml-helper.js";
 import { withFileLock } from "../utils/file-lock.js";
 import { loadConfig } from "../utils/config-loader.js";
+import { toMaidTaskStatus } from "../types/index.js";
 /**
  * 報告書ファイルからタスクIDを抽出
  *
@@ -162,13 +163,8 @@ async function syncMaidYaml(projectPath, task, params, prevAssignees) {
         try {
             await withFileLock(maidYamlPath, async () => {
                 const maidYaml = await readYamlFile(maidYamlPath);
-                // tasks.yaml → maid yaml 同期
-                // status 変換: "pending"/"cancelled" → "idle"、それ以外はそのまま
-                const STATUS_MAP = {
-                    pending: "idle",
-                    cancelled: "idle",
-                };
-                const maidStatus = STATUS_MAP[task.status] ?? task.status;
+                // tasks.yaml → maid yaml 同期（status変換は共通ユーティリティに委譲）
+                const maidStatus = toMaidTaskStatus(task.status);
                 maidYaml.task_id = `task-${task.id}`;
                 maidYaml.title = task.title;
                 maidYaml.description = params.description ?? task.description;

--- a/global-templates/maid-agent-messenger/dist/types/index.d.ts
+++ b/global-templates/maid-agent-messenger/dist/types/index.d.ts
@@ -3,7 +3,8 @@
  * V2.1: Task/Work/Step/Investigation 階層構造対応
  * V5.0.0: @maid-agent/types からの re-export を追加
  */
-export type { Task, Assignee, TaskSummary, TasksData, UpdateTaskParams, SideEffectResults, UpdateTaskResult, EscalationInfo, OperatorRole, StatusTransitionValidation, } from "@maid-agent/types";
+import type { TaskStatus as SourceTaskStatus } from "@maid-agent/types";
+export type { Task, Assignee, TaskSummary, TasksData, UpdateTaskParams, SideEffectResults, UpdateTaskResult, EscalationInfo, OperatorRole, StatusTransitionValidation, TaskStatus as SourceTaskStatus, } from "@maid-agent/types";
 export declare const MAID_IDS: readonly ["emma", "sophia", "lily", "rose", "alice", "may", "flora", "luna"];
 export type MaidId = (typeof MAID_IDS)[number];
 export declare const ALL_AGENT_IDS: readonly ["butler", "chief", "emma", "sophia", "lily", "rose", "alice", "may", "flora", "luna"];
@@ -101,7 +102,24 @@ export interface TaskYaml {
     started_at: string | null;
     completed_at: string | null;
     completion_summary: string | null;
+    /** 判断待ちで一時退避されたタスク一覧。最大1件（優先順位のブレ防止）。未使用時は省略可 */
+    parked_tasks?: ParkedTask[];
 }
+/**
+ * 一時退避（パーク）されたタスクの情報（task-1688-2・案B）。
+ * メイドが blocked 状態のまま別タスクを割り当てられた際、元のタスクをここへ退避する。
+ */
+export interface ParkedTask {
+    task_id: string;
+    title: string | null;
+    substatus: string | null;
+    parked_at: string;
+}
+/**
+ * tasks.yaml 側のタスクステータスを maid yaml（レガシー形式）へ変換する。
+ * syncMaidYaml（task-side-effects.ts）・resume-parked-task.ts の共通利用箇所。
+ */
+export declare function toMaidTaskStatus(status: SourceTaskStatus): LegacyTaskStatus;
 /**
  * 旧ステータスから V2.1 ステータスへの変換
  */

--- a/global-templates/maid-agent-messenger/dist/types/index.js
+++ b/global-templates/maid-agent-messenger/dist/types/index.js
@@ -106,6 +106,19 @@ export const TASK_CATEGORIES = [
 // =============================================================================
 // V2.1: ステータスマッピングユーティリティ
 // =============================================================================
+// tasks.yaml側ステータス → maid yaml（レガシー形式）変換テーブル
+// pending/cancelled は maid yaml 側に対応する状態がないため idle へ丸める
+const TASK_STATUS_TO_MAID_STATUS = {
+    pending: "idle",
+    cancelled: "idle",
+};
+/**
+ * tasks.yaml 側のタスクステータスを maid yaml（レガシー形式）へ変換する。
+ * syncMaidYaml（task-side-effects.ts）・resume-parked-task.ts の共通利用箇所。
+ */
+export function toMaidTaskStatus(status) {
+    return TASK_STATUS_TO_MAID_STATUS[status] ?? status;
+}
 /**
  * 旧ステータスから V2.1 ステータスへの変換
  */

--- a/packages/maid-agent-messenger/src/__tests__/routes/cli-api-routes.test.ts
+++ b/packages/maid-agent-messenger/src/__tests__/routes/cli-api-routes.test.ts
@@ -16,6 +16,7 @@ const mockExecuteAssignTask = jest.fn<any>();
 const mockExecuteGetMyTask = jest.fn<any>();
 const mockExecuteUpdateStatus = jest.fn<any>();
 const mockExecuteGetTeamStatus = jest.fn<any>();
+const mockExecuteResumeParkedTask = jest.fn<any>();
 
 jest.unstable_mockModule("../../services/index.js", () => ({
   executeCreateTask: mockExecuteCreateTask,
@@ -23,6 +24,7 @@ jest.unstable_mockModule("../../services/index.js", () => ({
   executeGetMyTask: mockExecuteGetMyTask,
   executeUpdateStatus: mockExecuteUpdateStatus,
   executeGetTeamStatus: mockExecuteGetTeamStatus,
+  executeResumeParkedTask: mockExecuteResumeParkedTask,
 }));
 
 jest.unstable_mockModule("../../middleware/project-path.js", () => ({
@@ -236,6 +238,75 @@ describe("GET /api/agents/:id/task", () => {
     expect(mockExecuteGetMyTask).toHaveBeenCalledWith(
       expect.objectContaining({ summaryOnly: true }),
     );
+  });
+});
+
+// ===========================================
+// POST /api/agents/:id/resume-parked-task - パーク中タスク再開（task-1688-2）
+// ===========================================
+describe("POST /api/agents/:id/resume-parked-task", () => {
+  it("パーク中タスクを再開する", async () => {
+    mockExecuteResumeParkedTask.mockResolvedValue({
+      success: true,
+      agent_id: "emma",
+      task_id: "task-199",
+    });
+
+    const res = await supertest(app)
+      .post("/api/agents/emma/resume-parked-task")
+      .send({ taskId: "task-199" })
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.task_id).toBe("task-199");
+    expect(mockExecuteResumeParkedTask).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "emma", taskId: "task-199" }),
+    );
+  });
+
+  it("無効なagentIdで400を返す", async () => {
+    const res = await supertest(app)
+      .post("/api/agents/invalid/resume-parked-task")
+      .send({ taskId: "task-199" })
+      .expect(400);
+
+    expect(res.body.error).toBe("Invalid agentId");
+  });
+
+  it("taskId未指定で400を返す", async () => {
+    const res = await supertest(app)
+      .post("/api/agents/emma/resume-parked-task")
+      .send({})
+      .expect(400);
+
+    expect(res.body.error).toBe("taskId is required");
+  });
+
+  it("サービスがエラーを返した場合400を返す", async () => {
+    mockExecuteResumeParkedTask.mockResolvedValue({
+      success: false,
+      agent_id: "emma",
+      task_id: "task-999",
+      error: "見つかりません",
+    });
+
+    const res = await supertest(app)
+      .post("/api/agents/emma/resume-parked-task")
+      .send({ taskId: "task-999" })
+      .expect(400);
+
+    expect(res.body.error).toBe("見つかりません");
+  });
+
+  it("サービス例外時に500を返す", async () => {
+    mockExecuteResumeParkedTask.mockRejectedValue(new Error("DB error"));
+
+    const res = await supertest(app)
+      .post("/api/agents/emma/resume-parked-task")
+      .send({ taskId: "task-199" })
+      .expect(500);
+
+    expect(res.body.error).toBe("Resume parked task failed");
   });
 });
 

--- a/packages/maid-agent-messenger/src/__tests__/services/assign-task.test.ts
+++ b/packages/maid-agent-messenger/src/__tests__/services/assign-task.test.ts
@@ -224,6 +224,123 @@ describe("executeAssignTask - unified-task-state-gateway", () => {
   });
 });
 
+// task-1688-2 案B: blocked状態のメイドへの割当（パーク・オン・アサイン）
+describe("executeAssignTask - パーク・オン・アサイン（task-1688-2）", () => {
+  it("blocked状態・parked_tasksなしの場合、現在のタスクをパークしてから新タスクを割り当てる", async () => {
+    mockedReadYamlFile.mockResolvedValue({
+      task_id: "task-071",
+      title: "旧タスク",
+      description: "旧タスク説明",
+      target_path: null,
+      status: "blocked",
+      substatus: "checkpoint",
+      assigned_at: "2026-08-01T00:00:00Z",
+      started_at: "2026-08-01T00:00:00Z",
+      completed_at: null,
+      completion_summary: null,
+    });
+
+    const { writeYamlFile } = await import("../../utils/yaml-helper.js");
+    const mockedWriteYamlFile = writeYamlFile as jest.MockedFunction<typeof writeYamlFile>;
+
+    const result = await executeAssignTask(baseParams);
+
+    expect(result.success).toBe(true);
+    // パーク書き込みが行われる
+    expect(mockedWriteYamlFile).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        parked_tasks: expect.arrayContaining([
+          expect.objectContaining({ task_id: "task-071", title: "旧タスク", substatus: "checkpoint" }),
+        ]),
+      })
+    );
+    // 新タスクの割当自体は通常どおり executeUpdateTask 経由で行われる
+    expect(mockedExecuteUpdateTask).toHaveBeenCalledWith(
+      "/project",
+      expect.objectContaining({ taskId: "072", status: "assigned" })
+    );
+  });
+
+  it("blocked状態・parked_tasksが既に1件ある場合、割当を拒否する", async () => {
+    mockedReadYamlFile.mockResolvedValue({
+      task_id: "task-071",
+      title: "旧タスク",
+      description: null,
+      target_path: null,
+      status: "blocked",
+      substatus: "checkpoint",
+      assigned_at: null,
+      started_at: null,
+      completed_at: null,
+      completion_summary: null,
+      parked_tasks: [
+        { task_id: "task-070", title: "既にパーク中のタスク", substatus: "checkpoint", parked_at: "2026-08-01T00:00:00Z" },
+      ],
+    });
+
+    const result = await executeAssignTask(baseParams);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("task-070");
+    expect(mockedExecuteUpdateTask).not.toHaveBeenCalled();
+  });
+
+  it("パーク書き込みはロック内で再読込した最新状態を使う（TOCTOU対策・メイのレビューSHOULD(a)）", async () => {
+    // 1回目の読み込み（ガード確認用）と2回目（パーク書き込み直前の再読込）で異なる値を返し、
+    // 実際に書き込まれる内容が「再読込後」の値であることを確認する
+    mockedReadYamlFile
+      .mockResolvedValueOnce({
+        task_id: "task-071",
+        title: "旧タスク（ガード確認時点）",
+        description: null,
+        target_path: null,
+        status: "blocked",
+        substatus: "checkpoint",
+        assigned_at: null,
+        started_at: null,
+        completed_at: null,
+        completion_summary: null,
+      })
+      .mockResolvedValueOnce({
+        task_id: "task-071",
+        title: "旧タスク（再読込後）",
+        description: null,
+        target_path: null,
+        status: "blocked",
+        substatus: "checkpoint",
+        assigned_at: null,
+        started_at: null,
+        completed_at: null,
+        completion_summary: null,
+      });
+
+    const { writeYamlFile } = await import("../../utils/yaml-helper.js");
+    const mockedWriteYamlFile = writeYamlFile as jest.MockedFunction<typeof writeYamlFile>;
+
+    await executeAssignTask(baseParams);
+
+    expect(mockedWriteYamlFile).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        parked_tasks: expect.arrayContaining([
+          expect.objectContaining({ task_id: "task-071", title: "旧タスク（再読込後）" }),
+        ]),
+      })
+    );
+    expect(mockedReadYamlFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("idle状態のメイドへの割当ではparked_tasksを書き込まない（既存挙動の回帰確認）", async () => {
+    const { writeYamlFile } = await import("../../utils/yaml-helper.js");
+    const mockedWriteYamlFile = writeYamlFile as jest.MockedFunction<typeof writeYamlFile>;
+
+    await executeAssignTask(baseParams);
+
+    expect(mockedWriteYamlFile).not.toHaveBeenCalled();
+  });
+});
+
 describe("executeAssignTask - force フラグ", () => {
   it("既存 assignees がある場合、force なしでエラーを返す", async () => {
     // Arrange: タスクに既に assignee がいる状態

--- a/packages/maid-agent-messenger/src/__tests__/services/get-my-task.test.ts
+++ b/packages/maid-agent-messenger/src/__tests__/services/get-my-task.test.ts
@@ -166,4 +166,57 @@ describe("executeGetMyTask", () => {
     expect(result.task_id).toBe("task-100-1");
     expect(result.parent_chain).toBeUndefined();
   });
+
+  // task-1688-2 案B: パーク中タスクの可視化
+  describe("parked_tasks（task-1688-2）", () => {
+    it("parked_tasksがある場合、結果にそのまま含まれる", async () => {
+      const agentYaml = stringifyYaml({
+        task_id: "task-200",
+        description: "新タスク",
+        status: "assigned",
+        assigned_at: "2026-08-07T10:00:00Z",
+        parked_tasks: [
+          {
+            task_id: "task-199",
+            title: "判断待ちタスク",
+            substatus: "checkpoint",
+            parked_at: "2026-08-07T09:00:00Z",
+          },
+        ],
+      });
+      await fs.writeFile(path.join(queueMaidPath, "flora.yaml"), agentYaml);
+
+      const result = await executeGetMyTask({
+        queueMaidPath,
+        agentId: "flora",
+      });
+
+      expect(result.parked_tasks).toEqual([
+        {
+          task_id: "task-199",
+          title: "判断待ちタスク",
+          substatus: "checkpoint",
+          parked_at: "2026-08-07T09:00:00Z",
+        },
+      ]);
+    });
+
+    it("parked_tasksがない場合、既存レスポンス形状を壊さない（回帰確認）", async () => {
+      const agentYaml = stringifyYaml({
+        task_id: "task-100",
+        description: "テストタスク",
+        status: "working",
+        assigned_at: "2026-02-25T10:00:00Z",
+      });
+      await fs.writeFile(path.join(queueMaidPath, "flora.yaml"), agentYaml);
+
+      const result = await executeGetMyTask({
+        queueMaidPath,
+        agentId: "flora",
+      });
+
+      expect(result.task_id).toBe("task-100");
+      expect(result.parked_tasks).toBeUndefined();
+    });
+  });
 });

--- a/packages/maid-agent-messenger/src/__tests__/services/resume-parked-task.test.ts
+++ b/packages/maid-agent-messenger/src/__tests__/services/resume-parked-task.test.ts
@@ -104,6 +104,7 @@ describe("executeResumeParkedTask - idle分岐（task_id=null）", () => {
         title: "判断待ちタスク",
         description: "判断待ちタスクの説明",
         target_path: "/src/parked/",
+        assigned_at: "2026-08-07T12:00:00Z",
         parked_tasks: [],
       })
     );
@@ -133,6 +134,8 @@ describe("executeResumeParkedTask - completed分岐", () => {
       expect.any(String),
       expect.objectContaining({
         task_id: "task-199",
+        assigned_at: "2026-08-07T12:00:00Z",
+        started_at: "2026-08-01T00:00:00Z",
         parked_tasks: [],
       })
     );
@@ -162,6 +165,7 @@ describe("executeResumeParkedTask - blocked分岐（スワップ）", () => {
       expect.any(String),
       expect.objectContaining({
         task_id: "task-199",
+        assigned_at: "2026-08-07T12:00:00Z",
         parked_tasks: [
           expect.objectContaining({ task_id: "task-200", title: "新タスク（判断待ち中）" }),
         ],

--- a/packages/maid-agent-messenger/src/__tests__/services/resume-parked-task.test.ts
+++ b/packages/maid-agent-messenger/src/__tests__/services/resume-parked-task.test.ts
@@ -1,0 +1,222 @@
+/**
+ * resume-parked-task テスト（task-1688-2 案B）
+ *
+ * パーク中タスクの再開ロジック。maid yaml の task_id/parked_tasks を
+ * ローカルでスワップ・昇格するのみで、tasks.yaml のstatus遷移（blocked→working）は
+ * 対象外（既存の maidctl set my-status が引き続き担う）。
+ */
+
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+
+jest.unstable_mockModule("../../utils/yaml-helper.js", () => ({
+  readYamlFile: jest.fn(),
+  writeYamlFile: jest.fn(),
+  getTimestamp: jest.fn(() => "2026-08-07T12:00:00Z"),
+}));
+
+jest.unstable_mockModule("../../utils/file-lock.js", () => ({
+  withFileLock: jest.fn(),
+}));
+
+jest.unstable_mockModule("../../services/task-manager.js", () => ({
+  executeGetTask: jest.fn(),
+}));
+
+const { executeResumeParkedTask } = await import("../../services/resume-parked-task.js");
+const { readYamlFile, writeYamlFile } = await import("../../utils/yaml-helper.js");
+const { withFileLock } = await import("../../utils/file-lock.js");
+const { executeGetTask } = await import("../../services/task-manager.js");
+
+const mockedReadYamlFile = readYamlFile as jest.MockedFunction<typeof readYamlFile>;
+const mockedWriteYamlFile = writeYamlFile as jest.MockedFunction<typeof writeYamlFile>;
+const mockedWithFileLock = withFileLock as jest.MockedFunction<typeof withFileLock>;
+const mockedExecuteGetTask = executeGetTask as jest.MockedFunction<typeof executeGetTask>;
+
+const baseParams = {
+  queueMaidPath: "/project/.maid-agent/system/data/maid",
+  projectPath: "/project",
+  agentId: "emma",
+  taskId: "task-199",
+};
+
+const parkedEntry = {
+  task_id: "task-199",
+  title: "判断待ちタスク",
+  substatus: "checkpoint",
+  parked_at: "2026-08-07T09:00:00Z",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  mockedWithFileLock.mockImplementation(
+    (async (_path: string, callback: () => Promise<unknown>) => {
+      return await callback();
+    }) as typeof withFileLock
+  );
+
+  mockedExecuteGetTask.mockResolvedValue({
+    task: {
+      id: "199",
+      parentId: null,
+      title: "判断待ちタスク",
+      description: "判断待ちタスクの説明",
+      priority: "medium" as const,
+      status: "blocked" as const,
+      substatus: "checkpoint",
+      category: "task" as const,
+      assignees: [{ agentId: "emma", role: null, subTaskId: null }],
+      targetPath: "/src/parked/",
+      createdAt: "2026-08-01T00:00:00Z",
+      updatedAt: "2026-08-07T09:00:00Z",
+      assignedAt: "2026-08-01T00:00:00Z",
+      startedAt: "2026-08-01T00:00:00Z",
+      completedAt: null,
+      reportPaths: [],
+      summary: null,
+    },
+  });
+});
+
+describe("executeResumeParkedTask - idle分岐（task_id=null）", () => {
+  it("アクティブタスクがない場合、パーク中タスクをそのまま昇格する", async () => {
+    mockedReadYamlFile.mockResolvedValue({
+      task_id: null,
+      title: null,
+      description: null,
+      target_path: null,
+      status: "idle",
+      substatus: null,
+      assigned_at: null,
+      started_at: null,
+      completed_at: null,
+      completion_summary: null,
+      parked_tasks: [parkedEntry],
+    });
+
+    const result = await executeResumeParkedTask(baseParams);
+
+    expect(result.success).toBe(true);
+    expect(mockedWriteYamlFile).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        task_id: "task-199",
+        title: "判断待ちタスク",
+        description: "判断待ちタスクの説明",
+        target_path: "/src/parked/",
+        parked_tasks: [],
+      })
+    );
+  });
+});
+
+describe("executeResumeParkedTask - completed分岐", () => {
+  it("アクティブタスクが完了済みの場合、パーク中タスクをそのまま昇格する", async () => {
+    mockedReadYamlFile.mockResolvedValue({
+      task_id: "task-200",
+      title: "新タスク",
+      description: "新タスク説明",
+      target_path: null,
+      status: "completed",
+      substatus: "completed",
+      assigned_at: "2026-08-05T00:00:00Z",
+      started_at: "2026-08-05T00:00:00Z",
+      completed_at: "2026-08-07T08:00:00Z",
+      completion_summary: "完了しました",
+      parked_tasks: [parkedEntry],
+    });
+
+    const result = await executeResumeParkedTask(baseParams);
+
+    expect(result.success).toBe(true);
+    expect(mockedWriteYamlFile).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        task_id: "task-199",
+        parked_tasks: [],
+      })
+    );
+  });
+});
+
+describe("executeResumeParkedTask - blocked分岐（スワップ）", () => {
+  it("アクティブタスクがblockedの場合、現在のアクティブタスクをparked_tasksへ退避してから昇格する", async () => {
+    mockedReadYamlFile.mockResolvedValue({
+      task_id: "task-200",
+      title: "新タスク（判断待ち中）",
+      description: "新タスク説明",
+      target_path: null,
+      status: "blocked",
+      substatus: "checkpoint",
+      assigned_at: "2026-08-05T00:00:00Z",
+      started_at: "2026-08-05T00:00:00Z",
+      completed_at: null,
+      completion_summary: null,
+      parked_tasks: [parkedEntry],
+    });
+
+    const result = await executeResumeParkedTask(baseParams);
+
+    expect(result.success).toBe(true);
+    expect(mockedWriteYamlFile).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        task_id: "task-199",
+        parked_tasks: [
+          expect.objectContaining({ task_id: "task-200", title: "新タスク（判断待ち中）" }),
+        ],
+      })
+    );
+  });
+});
+
+describe("executeResumeParkedTask - working分岐（拒否）", () => {
+  it("アクティブタスクが進行中の場合、再開を拒否する", async () => {
+    mockedReadYamlFile.mockResolvedValue({
+      task_id: "task-200",
+      title: "進行中タスク",
+      description: null,
+      target_path: null,
+      status: "working",
+      substatus: "working",
+      assigned_at: "2026-08-05T00:00:00Z",
+      started_at: "2026-08-05T00:00:00Z",
+      completed_at: null,
+      completion_summary: null,
+      parked_tasks: [parkedEntry],
+    });
+
+    const result = await executeResumeParkedTask(baseParams);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("task-200");
+    expect(mockedWriteYamlFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("executeResumeParkedTask - エラーケース", () => {
+  it("存在しないTASK_IDの場合はエラーを返す", async () => {
+    mockedReadYamlFile.mockResolvedValue({
+      task_id: "task-200",
+      title: "新タスク",
+      description: null,
+      target_path: null,
+      status: "idle",
+      substatus: null,
+      assigned_at: null,
+      started_at: null,
+      completed_at: null,
+      completion_summary: null,
+      parked_tasks: [parkedEntry],
+    });
+
+    const result = await executeResumeParkedTask({
+      ...baseParams,
+      taskId: "task-999",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("task-999");
+    expect(mockedWriteYamlFile).not.toHaveBeenCalled();
+  });
+});

--- a/packages/maid-agent-messenger/src/routes/cli-api-routes.ts
+++ b/packages/maid-agent-messenger/src/routes/cli-api-routes.ts
@@ -18,6 +18,7 @@ import {
   executeGetMyTask,
   executeUpdateStatus,
   executeGetTeamStatus,
+  executeResumeParkedTask,
 } from "../services/index.js";
 import { getProjectPathFromRequest } from "../middleware/project-path.js";
 import { MAID_IDS, type UpdatableStatus } from "../types/index.js";
@@ -218,6 +219,57 @@ router.get("/api/agents/:id/task", async (req: Request, res: Response) => {
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
     res.status(500).json({ error: "Task retrieval failed", details: message });
+  }
+});
+
+// =============================================================================
+// POST /api/agents/:id/resume-parked-task - パーク中タスク再開（task-1688-2・案B）
+// =============================================================================
+router.post("/api/agents/:id/resume-parked-task", async (req: Request, res: Response) => {
+  try {
+    const projectPath = getProjectPathFromRequest(req);
+    const agentId = req.params.id;
+    const { taskId } = req.body;
+
+    if (!MAID_IDS.includes(agentId as typeof MAID_IDS[number])) {
+      res.status(400).json({
+        error: "Invalid agentId",
+        validAgents: MAID_IDS,
+      });
+      return;
+    }
+
+    if (!taskId || typeof taskId !== "string") {
+      res.status(400).json({ error: "taskId is required" });
+      return;
+    }
+
+    const paths = buildInternalPaths(projectPath);
+
+    const result = await executeResumeParkedTask({
+      queueMaidPath: paths.queueMaidPath,
+      projectPath,
+      agentId,
+      taskId,
+    });
+
+    if (!result.success) {
+      res.status(400).json({
+        error: result.error || "Resume failed",
+        agentId,
+        taskId,
+      });
+      return;
+    }
+
+    res.json({
+      success: true,
+      agent_id: result.agent_id,
+      task_id: result.task_id,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    res.status(500).json({ error: "Resume parked task failed", details: message });
   }
 });
 

--- a/packages/maid-agent-messenger/src/services/assign-task.ts
+++ b/packages/maid-agent-messenger/src/services/assign-task.ts
@@ -7,10 +7,11 @@
  */
 
 import path from "path";
-import type { AssignTaskOutput } from "../types/index.js";
-import { readYamlFile } from "../utils/yaml-helper.js";
+import type { AssignTaskOutput, ParkedTask } from "../types/index.js";
+import { readYamlFile, writeYamlFile, getTimestamp } from "../utils/yaml-helper.js";
 import { withFileLock } from "../utils/file-lock.js";
 import { executeUpdateTask, executeGetTask, executeGetTaskChildren } from "./task-manager.js";
+import type { Assignee } from "./task-manager.js";
 import { normalizeTaskId } from "../utils/task-id.js";
 
 export interface AssignTaskParams {
@@ -52,6 +53,53 @@ export async function executeAssignTask(
     };
   }
 
+  // task-1688-2（案B）: blocked状態（判断待ち）のメイドへは、現在のタスクをパークしてから
+  // 新タスクの割当へ進む（パーク・オン・アサイン）。parked_tasksは最大1件（優先順位のブレ防止）。
+  if (maidTask.status === "blocked") {
+    const guardParked = maidTask.parked_tasks ?? [];
+    if (guardParked.length > 0) {
+      return {
+        success: false,
+        assigned_to: targetAgent,
+        task_id: maidTask.task_id || "",
+        error: `${targetAgent} は既にパーク中タスク（${guardParked[0]!.task_id}）を保持しています。先にresolveするか、別メイドへの配分を検討してください。`,
+      };
+    }
+
+    // メイのレビューSHOULD(a): ガード確認時点のスナップショット（maidTask）は書き込みに使わず、
+    // 新しいロックの中で再読込した最新状態を元にパーク判定・書き込みを行う（TOCTOU対策）。
+    let parkConflict: string | null = null;
+    await withFileLock(filePath, async () => {
+      const latest = await readYamlFile(filePath);
+      const latestParked = latest.parked_tasks ?? [];
+      if (latestParked.length > 0) {
+        parkConflict = latestParked[0]!.task_id;
+        return;
+      }
+      if (!latest.task_id) return;
+
+      const parkedEntry: ParkedTask = {
+        task_id: latest.task_id,
+        title: latest.title,
+        substatus: latest.substatus,
+        parked_at: getTimestamp(),
+      };
+      await writeYamlFile(filePath, {
+        ...latest,
+        parked_tasks: [parkedEntry],
+      });
+    });
+
+    if (parkConflict) {
+      return {
+        success: false,
+        assigned_to: targetAgent,
+        task_id: maidTask.task_id || "",
+        error: `${targetAgent} は既にパーク中タスク（${parkConflict}）を保持しています。先にresolveするか、別メイドへの配分を検討してください。`,
+      };
+    }
+  }
+
   // executeUpdateTask に全処理を委譲（maid yaml ロック解放済み）
   const projectPath = path.resolve(queueMaidPath, "..", "..", "..", "..");
   const taskIdNormalized = normalizeTaskId(taskId);
@@ -77,7 +125,7 @@ export async function executeAssignTask(
   // 既存 assignees チェック
   if (taskResult.task && taskResult.task.assignees && taskResult.task.assignees.length > 0) {
     if (!force) {
-      const existingAgents = taskResult.task.assignees.map(a => a.agentId).join(", ");
+      const existingAgents = taskResult.task.assignees.map((a: Assignee) => a.agentId).join(", ");
       return {
         success: false,
         assigned_to: targetAgent,

--- a/packages/maid-agent-messenger/src/services/get-my-task.ts
+++ b/packages/maid-agent-messenger/src/services/get-my-task.ts
@@ -7,7 +7,7 @@
 import path from "path";
 import fs from "fs/promises";
 import { parse } from "yaml";
-import type { GetMyTaskOutput } from "../types/index.js";
+import type { GetMyTaskOutput, ParkedTask } from "../types/index.js";
 import { readYamlFile, getFirstLine, fileExists } from "../utils/yaml-helper.js";
 import { logger } from "../utils/logger.js";
 
@@ -32,6 +32,7 @@ export interface ParentTaskInfo {
 export interface GetMyTaskResult extends GetMyTaskOutput {
   message?: string;
   parent_chain?: ParentTaskInfo[];  // 親タスクの階層（Task→Work→...）
+  parked_tasks?: ParkedTask[];      // task-1688-2（案B）: パーク中タスク一覧
 }
 
 /**
@@ -158,5 +159,7 @@ export async function executeGetMyTask(
     assigned_at: task.assigned_at || null,
     started_at: task.started_at || null,
     ...(parentChain && parentChain.length > 0 && { parent_chain: parentChain }),
+    // task-1688-2（案B）: パーク中タスク一覧（0件なら省略・既存レスポンス形状を維持）
+    ...(task.parked_tasks && task.parked_tasks.length > 0 && { parked_tasks: task.parked_tasks }),
   };
 }

--- a/packages/maid-agent-messenger/src/services/index.ts
+++ b/packages/maid-agent-messenger/src/services/index.ts
@@ -7,6 +7,11 @@
 export { executeGetMyTask, type GetMyTaskParams, type GetMyTaskResult } from "./get-my-task.js";
 export { executeUpdateStatus, type UpdateStatusParams } from "./update-status.js";
 export { executeAssignTask, type AssignTaskParams } from "./assign-task.js";
+export {
+  executeResumeParkedTask,
+  type ResumeParkedTaskParams,
+  type ResumeParkedTaskOutput,
+} from "./resume-parked-task.js";
 export { executeGetTeamStatus, type GetTeamStatusParams } from "./get-team-status.js";
 
 // タスク管理サービス（V2.1）

--- a/packages/maid-agent-messenger/src/services/resume-parked-task.ts
+++ b/packages/maid-agent-messenger/src/services/resume-parked-task.ts
@@ -115,7 +115,9 @@ export async function executeResumeParkedTask(
       target_path: freshTask.targetPath ?? null,
       status: toMaidTaskStatus(freshTask.status),
       substatus: freshTask.substatus,
-      assigned_at: freshTask.assignedAt,
+      // 計画書§3-6手順3: assigned_atのみ「再開」を表す現在時刻で更新する。
+      // started_at/completed_at等はtasks.yaml側の値をそのまま据え置き、既存タスクの経過を保持する。
+      assigned_at: getTimestamp(),
       started_at: freshTask.startedAt,
       completed_at: freshTask.completedAt,
       completion_summary: freshTask.summary,

--- a/packages/maid-agent-messenger/src/services/resume-parked-task.ts
+++ b/packages/maid-agent-messenger/src/services/resume-parked-task.ts
@@ -1,0 +1,135 @@
+/**
+ * resume_parked_task ビジネスロジック（task-1688-2・案B）
+ *
+ * パーク中タスクを maid yaml のアクティブスロットへ再開（昇格）する。
+ * tasks.yaml 側のstatus遷移（blocked→working）は対象外——それは引き続き
+ * メイド自身が `maidctl set my-status working` で行う（update-status.ts は無改修）。
+ * 本関数は「メイドのアクティブスロットがどのタスクを指すか」というローカルな
+ * スワップ・昇格のみを担う。
+ *
+ * 優先順位のブレ防止: 自動昇格は一切行わない。チーフが明示的にこの関数（コマンド）を
+ * 呼んだときのみ再開が発生する。
+ */
+
+import path from "path";
+import type { ParkedTask, TaskYaml } from "../types/index.js";
+import { toMaidTaskStatus } from "../types/index.js";
+import { readYamlFile, writeYamlFile, getTimestamp } from "../utils/yaml-helper.js";
+import { withFileLock } from "../utils/file-lock.js";
+import { executeGetTask } from "./task-manager.js";
+import type { Task, TaskSummary } from "./task-manager.js";
+import { normalizeTaskId } from "../utils/task-id.js";
+
+/**
+ * executeGetTask は summaryOnly 未指定時（本モジュールの呼び出し方）は必ず
+ * 完全な Task を返すが、戻り値の静的型は Task | TaskSummary の合併型のまま。
+ * TaskSummary には無い description で判定して狭める。
+ */
+function isFullTask(task: Task | TaskSummary): task is Task {
+  return "description" in task;
+}
+
+export interface ResumeParkedTaskParams {
+  queueMaidPath: string;
+  projectPath: string;
+  agentId: string;
+  /** 再開対象のパーク中タスクID */
+  taskId: string;
+}
+
+export interface ResumeParkedTaskOutput {
+  success: boolean;
+  agent_id: string;
+  task_id: string;
+  error?: string;
+}
+
+export async function executeResumeParkedTask(
+  params: ResumeParkedTaskParams
+): Promise<ResumeParkedTaskOutput> {
+  const { queueMaidPath, projectPath, agentId, taskId } = params;
+  const filePath = path.join(queueMaidPath, `${agentId}.yaml`);
+  const taskIdNormalized = normalizeTaskId(taskId);
+  const fullTaskId = `task-${taskIdNormalized}`;
+
+  let output: ResumeParkedTaskOutput | null = null;
+
+  await withFileLock(filePath, async () => {
+    const maidYaml = await readYamlFile(filePath);
+    const parkedTasks = maidYaml.parked_tasks ?? [];
+    const parkedIndex = parkedTasks.findIndex((p) => p.task_id === fullTaskId);
+
+    if (parkedIndex === -1) {
+      output = {
+        success: false,
+        agent_id: agentId,
+        task_id: fullTaskId,
+        error: `${agentId} のパーク中タスクに ${fullTaskId} が見つかりません。`,
+      };
+      return;
+    }
+
+    // アクティブタスクが進行中（working）の場合は再開を拒否する（安全側。強制中断はしない）
+    if (maidYaml.status === "working") {
+      output = {
+        success: false,
+        agent_id: agentId,
+        task_id: fullTaskId,
+        error: `${agentId} は現在 ${maidYaml.task_id} で作業中です。完了を待ってから再開してください。`,
+      };
+      return;
+    }
+
+    // 再開対象タスクの最新情報を tasks.yaml から取得する（title/description/target_path等の
+    // 鮮度を保証するため、パーク時点のスナップショット=ParkedTaskではなく都度再取得する）
+    const taskResult = await executeGetTask(projectPath, { taskId: taskIdNormalized });
+    if (!taskResult.task || !isFullTask(taskResult.task)) {
+      output = {
+        success: false,
+        agent_id: agentId,
+        task_id: fullTaskId,
+        error: `タスク #${fullTaskId} が tasks.yaml に見つかりません。`,
+      };
+      return;
+    }
+    const freshTask = taskResult.task;
+
+    const nextParkedTasks: ParkedTask[] = parkedTasks.filter((_, i) => i !== parkedIndex);
+
+    // アクティブタスクが blocked の場合のみ、現在のアクティブタスクをパークへ退避する
+    // （idle=task_id無し／completed=既に完了済み、のいずれもスワップ不要でそのまま昇格）
+    if (maidYaml.status === "blocked" && maidYaml.task_id) {
+      nextParkedTasks.push({
+        task_id: maidYaml.task_id,
+        title: maidYaml.title,
+        substatus: maidYaml.substatus,
+        parked_at: getTimestamp(),
+      });
+    }
+
+    const updated: TaskYaml = {
+      ...maidYaml,
+      task_id: fullTaskId,
+      title: freshTask.title,
+      description: freshTask.description,
+      target_path: freshTask.targetPath ?? null,
+      status: toMaidTaskStatus(freshTask.status),
+      substatus: freshTask.substatus,
+      assigned_at: freshTask.assignedAt,
+      started_at: freshTask.startedAt,
+      completed_at: freshTask.completedAt,
+      completion_summary: freshTask.summary,
+      parked_tasks: nextParkedTasks,
+    };
+
+    await writeYamlFile(filePath, updated);
+
+    output = {
+      success: true,
+      agent_id: agentId,
+      task_id: fullTaskId,
+    };
+  });
+
+  return output!;
+}

--- a/packages/maid-agent-messenger/src/services/task-side-effects.ts
+++ b/packages/maid-agent-messenger/src/services/task-side-effects.ts
@@ -23,6 +23,7 @@ import {
 import { withFileLock } from "../utils/file-lock.js";
 import { loadConfig } from "../utils/config-loader.js";
 import type { TaskYaml, TaskStatus as MaidTaskStatus } from "../types/index.js";
+import { toMaidTaskStatus } from "../types/index.js";
 
 /**
  * 報告書ファイルからタスクIDを抽出
@@ -202,13 +203,8 @@ async function syncMaidYaml(
       await withFileLock(maidYamlPath, async () => {
         const maidYaml = await readYamlFile<TaskYaml>(maidYamlPath);
 
-        // tasks.yaml → maid yaml 同期
-        // status 変換: "pending"/"cancelled" → "idle"、それ以外はそのまま
-        const STATUS_MAP: Record<string, MaidTaskStatus> = {
-          pending: "idle",
-          cancelled: "idle",
-        };
-        const maidStatus: MaidTaskStatus = STATUS_MAP[task.status] ?? task.status as MaidTaskStatus;
+        // tasks.yaml → maid yaml 同期（status変換は共通ユーティリティに委譲）
+        const maidStatus: MaidTaskStatus = toMaidTaskStatus(task.status);
 
         maidYaml.task_id = `task-${task.id}`;
         maidYaml.title = task.title;

--- a/packages/maid-agent-messenger/src/types/index.ts
+++ b/packages/maid-agent-messenger/src/types/index.ts
@@ -5,6 +5,7 @@
  */
 
 import { logger } from "../utils/logger.js";
+import type { TaskStatus as SourceTaskStatus } from "@maid-agent/types";
 
 // =============================================================================
 // @maid-agent/types からの re-export（共通型）
@@ -20,6 +21,7 @@ export type {
   EscalationInfo,
   OperatorRole,
   StatusTransitionValidation,
+  TaskStatus as SourceTaskStatus,
 } from "@maid-agent/types";
 
 // =============================================================================
@@ -264,11 +266,40 @@ export interface TaskYaml {
   started_at: string | null;
   completed_at: string | null;
   completion_summary: string | null;
+  // === task-1688-2（案B）: 判断待ちタスクの一時退避 ===
+  /** 判断待ちで一時退避されたタスク一覧。最大1件（優先順位のブレ防止）。未使用時は省略可 */
+  parked_tasks?: ParkedTask[];
+}
+
+/**
+ * 一時退避（パーク）されたタスクの情報（task-1688-2・案B）。
+ * メイドが blocked 状態のまま別タスクを割り当てられた際、元のタスクをここへ退避する。
+ */
+export interface ParkedTask {
+  task_id: string;
+  title: string | null;
+  substatus: string | null; // パーク時点のsubstatus（checkpoint/waiting）
+  parked_at: string;        // ISO timestamp
 }
 
 // =============================================================================
 // V2.1: ステータスマッピングユーティリティ
 // =============================================================================
+
+// tasks.yaml側ステータス → maid yaml（レガシー形式）変換テーブル
+// pending/cancelled は maid yaml 側に対応する状態がないため idle へ丸める
+const TASK_STATUS_TO_MAID_STATUS: Partial<Record<SourceTaskStatus, LegacyTaskStatus>> = {
+  pending: "idle",
+  cancelled: "idle",
+};
+
+/**
+ * tasks.yaml 側のタスクステータスを maid yaml（レガシー形式）へ変換する。
+ * syncMaidYaml（task-side-effects.ts）・resume-parked-task.ts の共通利用箇所。
+ */
+export function toMaidTaskStatus(status: SourceTaskStatus): LegacyTaskStatus {
+  return TASK_STATUS_TO_MAID_STATUS[status] ?? (status as LegacyTaskStatus);
+}
 
 /**
  * 旧ステータスから V2.1 ステータスへの変換


### PR DESCRIPTION
## Summary
- blocked状態（判断待ち）のメイドへ新タスクを割り当てる際、現在のタスクを`parked_tasks`（最大1件・優先順位のブレ防止）へ退避してから割当を続行する「パーク・オン・アサイン」を実装
- パーク中タスクの再開は`resume-parked-task`（チーフ専用の完全明示的操作）のみで発生。自動昇格は一切行わない
- `update-status.ts`は無改修（resume側でtask_idを直接昇格させる方式のため）、既存の単一スロット運用とは後方互換

## 設計判断（計画書 `.maid-agent/plans/task-1688-2_plan.md` 参照）
- task-1688-1設計検討レポートで推奨した案Bをご主人様裁定で採用
- task-1688-2-1（メイ）計画書レビューのSHOULD 2件を反映
  - (a) パーク書き込みはガード確認時点のスナップショットではなく、ロック内で再読込した最新状態を使用（TOCTOU対策）
  - (b) resume-parked-taskの4分岐にidle（task_id=null）ケースを独立分岐として明示

## Test plan
- [x] `packages/maid-agent-messenger`: 全43スイート533テストpass（新規: assign-task 4件、get-my-task 2件、resume-parked-task 5件、cli-api-routes 5件）
- [x] bashテスト（`global-templates/bin/test/`）: 全7ファイルpass（新規: `maidctl-resume-parked-task.test.sh`, `maidctl-format-my-task-parked.test.sh`）
- [x] `npm run build --workspace=packages/maid-agent-messenger` 成功
- [x] セルフレビュー完了（TOCTOU型ガード修正、ステータス変換ロジックの重複解消(`toMaidTaskStatus`共通化)、CLI側JSON エスケープ・タイムスタンプ生成の既存慣行への統一）

🤖 Generated with [Claude Code](https://claude.com/claude-code)